### PR TITLE
Adapt partitioning with Metis to allow the use of edge weights

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,123 @@
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never

--- a/DownElement.h
+++ b/DownElement.h
@@ -17,11 +17,9 @@
 #include <cstring>
 #include <unordered_set>
 
-namespace PUML
-{
+namespace PUML {
 
-namespace internal
-{
+namespace internal {
 
 /**
  * A hashable element defined by the global ids of
@@ -29,49 +27,38 @@ namespace internal
  *
  * @tparam N The number of down elements
  */
-template<unsigned int N>
-struct DownElement
-{
-	/** The global ids of the downward elements */
-	unsigned long down[N];
+template <unsigned int N> struct DownElement {
+  /** The global ids of the downward elements */
+  unsigned long down[N];
 
-	DownElement(const unsigned long down[N])
-	{
-		memcpy(this->down, down, N*sizeof(unsigned long));
-		std::sort(this->down, this->down+N);
-	}
+  DownElement(const unsigned long down[N]) {
+    memcpy(this->down, down, N * sizeof(unsigned long));
+    std::sort(this->down, this->down + N);
+  }
 
-	bool operator==(const DownElement &other) const
-	{
-		return memcmp(down, other.down, N*sizeof(unsigned long)) == 0;
-	}
+  bool operator==(const DownElement& other) const { return memcmp(down, other.down, N * sizeof(unsigned long)) == 0; }
 };
 
-template<unsigned int N>
-struct DownElementHash
-{
-	std::size_t operator()(const DownElement<N> &element) const
-	{
-		std::size_t h = std::hash<unsigned long>{}(element.down[0]);
-		for (unsigned int i = 1; i < N; i++)
-			hash_combine(h, element.down[i]);
+template <unsigned int N> struct DownElementHash {
+  std::size_t operator()(const DownElement<N>& element) const {
+    std::size_t h = std::hash<unsigned long>{}(element.down[0]);
+    for (unsigned int i = 1; i < N; i++)
+      hash_combine(h, element.down[i]);
 
-		return h;
-	}
+    return h;
+  }
 
-	/**
-	 * Taken from: https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
-	 */
-	template<typename T>
-	static void hash_combine(std::size_t& seed, const T& v)
-	{
-		std::hash<T> hasher;
-		seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-	}
+  /**
+   * Taken from: https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
+   */
+  template <typename T> static void hash_combine(std::size_t& seed, const T& v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
 };
 
-}
+} // namespace internal
 
-}
+} // namespace PUML
 
 #endif // PUML_DOWNELEMENT_H

--- a/Downward.h
+++ b/Downward.h
@@ -25,92 +25,86 @@
 #include "Topology.h"
 #include "Utils.h"
 
-namespace PUML
-{
+namespace PUML {
 
-class Downward
-{
-public:
-	/**
-	 * Returns all local face ids for a cell
-	 *
-	 * @param puml The PUML mesh
-	 * @param cell The cell for which the faces should be returned
-	 * @param lid The local ids of the faces
-	 */
-	template<TopoType Topo>
-	static void faces(const PUML<Topo> &puml, const typename PUML<Topo>::cell_t &cell, unsigned int* lid)
-	{
-		for (unsigned int i = 0; i < internal::Topology<Topo>::cellfaces(); i++) {
-			unsigned int v[internal::Topology<Topo>::facevertices()];
-			faceVertices(puml, cell, i, v);
+class Downward {
+  public:
+  /**
+   * Returns all local face ids for a cell
+   *
+   * @param puml The PUML mesh
+   * @param cell The cell for which the faces should be returned
+   * @param lid The local ids of the faces
+   */
+  template <TopoType Topo>
+  static void faces(const PUML<Topo>& puml, const typename PUML<Topo>::cell_t& cell, unsigned int* lid) {
+    for (unsigned int i = 0; i < internal::Topology<Topo>::cellfaces(); i++) {
+      unsigned int v[internal::Topology<Topo>::facevertices()];
+      faceVertices(puml, cell, i, v);
 
-			int id = puml.faceByVertices(v);
-			assert(id >= 0);
-			lid[i] = id;
-		}
-	}
+      int id = puml.faceByVertices(v);
+      assert(id >= 0);
+      lid[i] = id;
+    }
+  }
 
-	/**
-	 * Returns all local vertex ids for a cell
-	 *
-	 * @param puml The PUML mesh
-	 * @param cell The cell for which the vertices should be returned
-	 * @param lid The local ids of the vertices
-	 */
-	template<TopoType Topo>
-	static void vertices(const PUML<Topo> &puml, const typename PUML<Topo>::cell_t &cell, unsigned int* lid)
-	{
-		memcpy(lid, cell.m_vertices, internal::Topology<Topo>::cellvertices() * sizeof(unsigned int));
-	}
+  /**
+   * Returns all local vertex ids for a cell
+   *
+   * @param puml The PUML mesh
+   * @param cell The cell for which the vertices should be returned
+   * @param lid The local ids of the vertices
+   */
+  template <TopoType Topo>
+  static void vertices(const PUML<Topo>& puml, const typename PUML<Topo>::cell_t& cell, unsigned int* lid) {
+    memcpy(lid, cell.m_vertices, internal::Topology<Topo>::cellvertices() * sizeof(unsigned int));
+  }
 
-	/**
-	 * Returns all global vertex ids for a cell
-	 *
-	 * @param puml The PUML mesh
-	 * @param cell The cell for which the vertices should be returned
-	 * @param gid The global ids of the vertices
-	 */
-	template<TopoType Topo>
-	static void gvertices(const PUML<Topo> &puml, const typename PUML<Topo>::cell_t &cell, unsigned long* gid)
-	{
-		unsigned int lid[internal::Topology<Topo>::cellvertices()];
-		vertices(puml, cell, lid);
-		internal::Utils::l2g<Topo, typename PUML<Topo>::vertex_t, internal::Topology<Topo>::cellvertices()>(puml, lid, gid);
-	}
+  /**
+   * Returns all global vertex ids for a cell
+   *
+   * @param puml The PUML mesh
+   * @param cell The cell for which the vertices should be returned
+   * @param gid The global ids of the vertices
+   */
+  template <TopoType Topo>
+  static void gvertices(const PUML<Topo>& puml, const typename PUML<Topo>::cell_t& cell, unsigned long* gid) {
+    unsigned int lid[internal::Topology<Topo>::cellvertices()];
+    vertices(puml, cell, lid);
+    internal::Utils::l2g<Topo, typename PUML<Topo>::vertex_t, internal::Topology<Topo>::cellvertices()>(puml, lid, gid);
+  }
 
-	/**
-	 * @param faceId The local id of the face
-	 * @return The side of the cell this face is on or -1 of the face is on no side
-	 */
-	template<TopoType Topo>
-	static int faceSide(const PUML<Topo> &puml, const typename PUML<Topo>::cell_t &cell, unsigned int faceId)
-	{
-		unsigned int faceIds[internal::Topology<Topo>::cellfaces()];
-		faces(puml, cell, faceIds);
+  /**
+   * @param faceId The local id of the face
+   * @return The side of the cell this face is on or -1 of the face is on no side
+   */
+  template <TopoType Topo>
+  static int faceSide(const PUML<Topo>& puml, const typename PUML<Topo>::cell_t& cell, unsigned int faceId) {
+    unsigned int faceIds[internal::Topology<Topo>::cellfaces()];
+    faces(puml, cell, faceIds);
 
-		unsigned int* end = faceIds+internal::Topology<Topo>::cellfaces();
+    unsigned int* end = faceIds + internal::Topology<Topo>::cellfaces();
 
-		unsigned int* pFaceId = std::find(faceIds, end, faceId);
-		if (pFaceId == end)
-			return -1;
+    unsigned int* pFaceId = std::find(faceIds, end, faceId);
+    if (pFaceId == end)
+      return -1;
 
-		return pFaceId - faceIds;
-	}
+    return pFaceId - faceIds;
+  }
 
-	/**
-	 * @param faceSide The side of the cell
-	 */
-	template<TopoType Topo>
-	static void faceVertices(const PUML<Topo> &puml, const typename PUML<Topo>::cell_t &cell, unsigned int faceSide, unsigned int* lid)
-	{
-		assert(faceSide < internal::Topology<Topo>::cellfaces());
-		for (unsigned int i = 0; i < internal::Topology<Topo>::facevertices(); i++) {
-			lid[i] = cell.m_vertices[internal::Numbering<Topo>::facevertices()[faceSide][i]];
-		}
-	}
+  /**
+   * @param faceSide The side of the cell
+   */
+  template <TopoType Topo>
+  static void faceVertices(const PUML<Topo>& puml, const typename PUML<Topo>::cell_t& cell, unsigned int faceSide,
+                           unsigned int* lid) {
+    assert(faceSide < internal::Topology<Topo>::cellfaces());
+    for (unsigned int i = 0; i < internal::Topology<Topo>::facevertices(); i++) {
+      lid[i] = cell.m_vertices[internal::Numbering<Topo>::facevertices()[faceSide][i]];
+    }
+  }
 };
 
-}
+} // namespace PUML
 
 #endif // PUML_DOWNWARD_H

--- a/Element.h
+++ b/Element.h
@@ -17,110 +17,89 @@
 
 #include "Topology.h"
 
-namespace PUML
-{
+namespace PUML {
 
-namespace internal
-{
+namespace internal {
 
 class Utils;
 
 } // namespace internal
 
-template<TopoType Topo>
-class PUML;
+template <TopoType Topo> class PUML;
 class Downward;
 class Upward;
 
-template<typename utype>
-class Element
-{
-	template<TopoType Topo>
-	friend class PUML;
-	friend class Upward;
-	friend class internal::Utils;
+template <typename utype> class Element {
+  template <TopoType Topo> friend class PUML;
+  friend class Upward;
+  friend class internal::Utils;
 
-private:
-	/** The global id */
-	unsigned long m_gid;
+  private:
+  /** The global id */
+  unsigned long m_gid;
 
-	/** The local/global ids of the upper elements */
-	utype m_upward;
+  /** The local/global ids of the upper elements */
+  utype m_upward;
 
-public:
-	/**
-	 * @return The global ID of the element
-	 */
-	unsigned long gid() const
-	{ return m_gid; }
+  public:
+  /**
+   * @return The global ID of the element
+   */
+  unsigned long gid() const { return m_gid; }
 };
 
 /**
  * Elements that can be on partition boundaries (all except cells)
  */
-template<typename utype>
-class BoundaryElement : public Element<utype>
-{
-	template<TopoType Topo>
-	friend class PUML;
+template <typename utype> class BoundaryElement : public Element<utype> {
+  template <TopoType Topo> friend class PUML;
 
-private:
-	/** A listof ranks that contain the same vertex */
-	std::vector<int> m_sharedRanks;
+  private:
+  /** A listof ranks that contain the same vertex */
+  std::vector<int> m_sharedRanks;
 
-public:
-	/**
-	 * @return <code>True</code> if the element is on a partition boundary
-	 */
-	bool isShared() const
-	{ return m_sharedRanks.size() > 0; }
+  public:
+  /**
+   * @return <code>True</code> if the element is on a partition boundary
+   */
+  bool isShared() const { return m_sharedRanks.size() > 0; }
 
-	/**
-	 * @return A vector of ranks that also has this element
-	 */
-	const std::vector<int>& shared() const
-	{ return m_sharedRanks; }
+  /**
+   * @return A vector of ranks that also has this element
+   */
+  const std::vector<int>& shared() const { return m_sharedRanks; }
 };
 
-class Vertex : public BoundaryElement<std::vector<int> >
-{
-	template<TopoType Topo>
-	friend class PUML;
+class Vertex : public BoundaryElement<std::vector<int>> {
+  template <TopoType Topo> friend class PUML;
 
-private:
-	double m_coordinate[3];
+  private:
+  double m_coordinate[3];
 
-public:
-	/**
-	 * @return A pointer to an array with 3 components containing
-	 *  x, y and z
-	 */
-	const double* coordinate() const
-	{ return m_coordinate; }
+  public:
+  /**
+   * @return A pointer to an array with 3 components containing
+   *  x, y and z
+   */
+  const double* coordinate() const { return m_coordinate; }
 };
 
-class Edge : public BoundaryElement<std::vector<int> >
-{
-	template<TopoType Topo>
-	friend class PUML;
+class Edge : public BoundaryElement<std::vector<int>> {
+  template <TopoType Topo> friend class PUML;
 };
 
-class Face : public BoundaryElement<int[2]>
-{
-	template<TopoType Topo>
-	friend class PUML;
+class Face : public BoundaryElement<int[2]> {
+  template <TopoType Topo> friend class PUML;
 };
 
-template<TopoType Topo>
-class Cell : public Element<std::array<int, 0>>
-{
-	friend class PUML<Topo>;
-	friend class Downward;
+template <TopoType Topo> class Cell : public Element<std::array<int, 0>> {
+  friend class PUML<Topo>;
+  friend class Downward;
 
-private:
-	unsigned int m_vertices[internal::Topology<Topo>::cellvertices()];
+  private:
+  unsigned int m_vertices[internal::Topology<Topo>::cellvertices()];
 };
 
-}
+} // namespace PUML
 
 #endif // PUML_ELEMENT_H

--- a/Element.h
+++ b/Element.h
@@ -14,7 +14,7 @@
 #define PUML_ELEMENT_H
 
 #include <vector>
-
+#include <array>
 #include "Topology.h"
 
 namespace PUML {

--- a/Neighbor.h
+++ b/Neighbor.h
@@ -20,38 +20,34 @@
 #include "Topology.h"
 #include "Upward.h"
 
-namespace PUML
-{
+namespace PUML {
 
-class Neighbor
-{
-public:
-	/**
-	 * Returns all local neighor ids for a cell
-	 *
-	 * @param puml The PUML mesh
-	 * @param clid The local id of the cell for which the neighbors should be returned
-	 * @param flid The local ids of the neighbors or -1 if there is no local neighbor
-	 */
-	template<TopoType Topo>
-	static void face(const PUML<Topo> &puml, unsigned int clid, int* flid)
-	{
-		unsigned int faces[internal::Topology<Topo>::cellfaces()];
-		assert(clid < puml.cells().size());
-		Downward::faces(puml, puml.cells()[clid], faces);
+class Neighbor {
+  public:
+  /**
+   * Returns all local neighor ids for a cell
+   *
+   * @param puml The PUML mesh
+   * @param clid The local id of the cell for which the neighbors should be returned
+   * @param flid The local ids of the neighbors or -1 if there is no local neighbor
+   */
+  template <TopoType Topo> static void face(const PUML<Topo>& puml, unsigned int clid, int* flid) {
+    unsigned int faces[internal::Topology<Topo>::cellfaces()];
+    assert(clid < puml.cells().size());
+    Downward::faces(puml, puml.cells()[clid], faces);
 
-		for (unsigned int i = 0; i < internal::Topology<Topo>::cellfaces(); i++) {
-			int neighbors[2];
-			Upward::cells(puml, puml.faces()[faces[i]], neighbors);
+    for (unsigned int i = 0; i < internal::Topology<Topo>::cellfaces(); i++) {
+      int neighbors[2];
+      Upward::cells(puml, puml.faces()[faces[i]], neighbors);
 
-			if (static_cast<unsigned int>(neighbors[0]) == clid)
-				flid[i] = neighbors[1];
-			else
-				flid[i] = neighbors[0];
-		}
-	}
+      if (static_cast<unsigned int>(neighbors[0]) == clid)
+        flid[i] = neighbors[1];
+      else
+        flid[i] = neighbors[0];
+    }
+  }
 };
 
-}
+} // namespace PUML
 
 #endif // PUML_NEIGHBOR_H

--- a/Numbering.h
+++ b/Numbering.h
@@ -15,41 +15,33 @@
 
 #include "Topology.h"
 
-namespace PUML
-{
+namespace PUML {
 
-namespace internal
-{
+namespace internal {
 
-template<TopoType Topo>
-class Numbering
-{
-public:
-	typedef unsigned int face_t[Topology<Topo>::facevertices()];
+template <TopoType Topo>
+class Numbering {
+ public:
+  typedef unsigned int face_t[Topology<Topo>::facevertices()];
 
-	static const face_t* facevertices();
+  static const face_t* facevertices();
 };
 
-template<>
-class Numbering<TETRAHEDRON>
-{
-public:
-	typedef unsigned int face_t[Topology<TETRAHEDRON>::facevertices()];
+template <>
+class Numbering<TETRAHEDRON> {
+ public:
+  typedef unsigned int face_t[Topology<TETRAHEDRON>::facevertices()];
 
-	static const face_t* facevertices()
-	{
-		static const face_t vertices[4] = {
-			{ 1, 0, 2 },
-			{ 0, 1, 3 },
-			{ 1, 2, 3 },
-			{ 2, 0, 3 } };
+  static const face_t* facevertices() {
+    static const face_t vertices[4] = {
+      {1, 0, 2}, {0, 1, 3}, {1, 2, 3}, {2, 0, 3}};
 
-		return vertices;
-	}
+    return vertices;
+  }
 };
 
-}
+}  // namespace internal
 
-}
+}  // namespace PUML
 
-#endif // PUML_NUMBERING_H
+#endif  // PUML_NUMBERING_H

--- a/Numbering.h
+++ b/Numbering.h
@@ -19,29 +19,26 @@ namespace PUML {
 
 namespace internal {
 
-template <TopoType Topo>
-class Numbering {
- public:
+template <TopoType Topo> class Numbering {
+  public:
   typedef unsigned int face_t[Topology<Topo>::facevertices()];
 
   static const face_t* facevertices();
 };
 
-template <>
-class Numbering<TETRAHEDRON> {
- public:
+template <> class Numbering<TETRAHEDRON> {
+  public:
   typedef unsigned int face_t[Topology<TETRAHEDRON>::facevertices()];
 
   static const face_t* facevertices() {
-    static const face_t vertices[4] = {
-      {1, 0, 2}, {0, 1, 3}, {1, 2, 3}, {2, 0, 3}};
+    static const face_t vertices[4] = {{1, 0, 2}, {0, 1, 3}, {1, 2, 3}, {2, 0, 3}};
 
     return vertices;
   }
 };
 
-}  // namespace internal
+} // namespace internal
 
-}  // namespace PUML
+} // namespace PUML
 
-#endif  // PUML_NUMBERING_H
+#endif // PUML_NUMBERING_H

--- a/PUML.h
+++ b/PUML.h
@@ -35,1243 +35,1148 @@
 #include "Topology.h"
 #include "VertexElementMap.h"
 
-namespace PUML
-{
+namespace PUML {
 
-enum DataType
-{
-	CELL = 0,
-	VERTEX = 1
-};
+enum DataType { CELL = 0, VERTEX = 1 };
 
 #define checkH5Err(...) _checkH5Err(__VA_ARGS__, __FILE__, __LINE__)
 
 /**
  * @todo Handle non-MPI case correct
  */
-template<TopoType Topo>
-class PUML
-{
-public:
-	/** The cell type from the file */
-	typedef unsigned long ocell_t[internal::Topology<Topo>::cellvertices()];
+template <TopoType Topo> class PUML {
+  public:
+  /** The cell type from the file */
+  typedef unsigned long ocell_t[internal::Topology<Topo>::cellvertices()];
 
-	/** The vertex type from the file */
-	typedef double overtex_t[3];
+  /** The vertex type from the file */
+  typedef double overtex_t[3];
 
-	/** Internal cell type */
-	typedef Cell<Topo> cell_t;
+  /** Internal cell type */
+  typedef Cell<Topo> cell_t;
 
-	/** Internal face type */
-	typedef Face face_t;
+  /** Internal face type */
+  typedef Face face_t;
 
-	/** Internal edge type */
-	typedef Edge edge_t;
+  /** Internal edge type */
+  typedef Edge edge_t;
 
-	/** Internal vertex type */
-	typedef Vertex vertex_t;
-private:
+  /** Internal vertex type */
+  typedef Vertex vertex_t;
+
+  private:
 #ifdef USE_MPI
-	MPI_Comm m_comm;
+  MPI_Comm m_comm;
 #endif // USE_MPI
 
-	/** The original cells from the file */
-	ocell_t* m_originalCells;
+  /** The original cells from the file */
+  ocell_t* m_originalCells;
 
-	/** The original vertices from the file */
-	overtex_t* m_originalVertices;
+  /** The original vertices from the file */
+  overtex_t* m_originalVertices;
 
-	/** The original number of cells/vertices on each node */
-	unsigned int m_originalSize[2];
+  /** The original number of cells/vertices on each node */
+  unsigned int m_originalSize[2];
 
-	/** The original number of total cells/vertices */
-	unsigned long m_originalTotalSize[2];
+  /** The original number of total cells/vertices */
+  unsigned long m_originalTotalSize[2];
 
-	typedef std::unordered_map<unsigned long, unsigned int> g2l_t;
+  typedef std::unordered_map<unsigned long, unsigned int> g2l_t;
 
-	/** The list of all local cells */
-	std::vector<cell_t> m_cells;
+  /** The list of all local cells */
+  std::vector<cell_t> m_cells;
 
-	/** The list of all local faces */
-	std::vector<face_t> m_faces;
+  /** The list of all local faces */
+  std::vector<face_t> m_faces;
 
-	/** Mapping from global face ids to local face ids */
-	g2l_t m_facesg2l;
+  /** Mapping from global face ids to local face ids */
+  g2l_t m_facesg2l;
 
-	/** List of all local edges */
-	std::vector<edge_t> m_edges;
+  /** List of all local edges */
+  std::vector<edge_t> m_edges;
 
-	/** Mapping from global edge ids to local edge ids */
-	g2l_t m_edgesg2l;
+  /** Mapping from global edge ids to local edge ids */
+  g2l_t m_edgesg2l;
 
-	/** List of all local vertices */
-	std::vector<vertex_t> m_vertices;
+  /** List of all local vertices */
+  std::vector<vertex_t> m_vertices;
 
-	/** Mapping from global vertex ids to locl vertex ids */
-	g2l_t m_verticesg2l;
+  /** Mapping from global vertex ids to locl vertex ids */
+  g2l_t m_verticesg2l;
 
-	/** Maps from local vertex ids to to a local face ids */
-	internal::VertexElementMap<internal::Topology<Topo>::facevertices()> m_v2f;
+  /** Maps from local vertex ids to to a local face ids */
+  internal::VertexElementMap<internal::Topology<Topo>::facevertices()> m_v2f;
 
-	/** Maps from local vertex ids to local edge ids */
-	internal::VertexElementMap<2> m_v2e;
+  /** Maps from local vertex ids to local edge ids */
+  internal::VertexElementMap<2> m_v2e;
 
-	/** User cell data */
-	std::vector<int*> m_cellData;
+  /** User cell data */
+  std::vector<int*> m_cellData;
 
-	/** User vertex data */
-	std::vector<int*> m_vertexData;
+  /** User vertex data */
+  std::vector<int*> m_vertexData;
 
-	/** Original user vertex data */
-	std::vector<int*> m_originalVertexData;
-public:
-	PUML() :
+  /** Original user vertex data */
+  std::vector<int*> m_originalVertexData;
+
+  public:
+  PUML()
+      :
 #ifdef USE_MPI
-		m_comm(MPI_COMM_WORLD),
+        m_comm(MPI_COMM_WORLD),
 #endif // USE_MPI
-		m_originalCells(0L),
-		m_originalVertices(0L)
-	{ }
+        m_originalCells(0L), m_originalVertices(0L) {
+  }
 
-	virtual ~PUML()
-	{
-		delete [] m_originalCells;
-		delete [] m_originalVertices;
+  virtual ~PUML() {
+    delete[] m_originalCells;
+    delete[] m_originalVertices;
 
-		for (std::vector<int*>::const_iterator it = m_cellData.begin();
-				it != m_cellData.end(); ++it) {
-			delete [] *it;
-		}
+    for (std::vector<int*>::const_iterator it = m_cellData.begin(); it != m_cellData.end(); ++it) {
+      delete[] * it;
+    }
 
-		for (std::vector<int*>::const_iterator it = m_vertexData.begin();
-				it != m_vertexData.end(); ++it) {
-			delete [] *it;
-		}
+    for (std::vector<int*>::const_iterator it = m_vertexData.begin(); it != m_vertexData.end(); ++it) {
+      delete[] * it;
+    }
 
-		for (std::vector<int*>::const_iterator it = m_originalVertexData.begin();
-				it != m_originalVertexData.end(); ++it) {
-			delete [] *it;
-		}
-	}
+    for (std::vector<int*>::const_iterator it = m_originalVertexData.begin(); it != m_originalVertexData.end(); ++it) {
+      delete[] * it;
+    }
+  }
 
 #ifdef USE_MPI
-	void setComm(MPI_Comm comm)
-	{
-		m_comm = comm;
-	}
+  void setComm(MPI_Comm comm) { m_comm = comm; }
 #endif // USE_MPI
 
-	void open(const char* cellName, const char* vertexName)
-	{
-		int rank = 0;
-		int procs = 1;
+  void open(const char* cellName, const char* vertexName) {
+    int rank = 0;
+    int procs = 1;
 #ifdef USE_MPI
-		MPI_Comm_rank(m_comm, &rank);
-		MPI_Comm_size(m_comm, &procs);
+    MPI_Comm_rank(m_comm, &rank);
+    MPI_Comm_size(m_comm, &procs);
 #endif // USE_MPI
 
-		std::vector<std::string> cellNames = utils::StringUtils::split(cellName, ':');
-		if (cellNames.size() != 2)
-			logError() << "Cells name must have the form \"filename:/dataset\"";
+    std::vector<std::string> cellNames = utils::StringUtils::split(cellName, ':');
+    if (cellNames.size() != 2)
+      logError() << "Cells name must have the form \"filename:/dataset\"";
 
-		std::vector<std::string> vertexNames = utils::StringUtils::split(vertexName, ':');
-		if (vertexNames.size() != 2)
-			logError() << "Vertices name must have the form \"filename:/dataset\"";
+    std::vector<std::string> vertexNames = utils::StringUtils::split(vertexName, ':');
+    if (vertexNames.size() != 2)
+      logError() << "Vertices name must have the form \"filename:/dataset\"";
 
-		// Open the cell file
-		hid_t h5plist = H5Pcreate(H5P_FILE_ACCESS);
-		checkH5Err(h5plist);
+    // Open the cell file
+    hid_t h5plist = H5Pcreate(H5P_FILE_ACCESS);
+    checkH5Err(h5plist);
 #ifdef USE_MPI
-		checkH5Err(H5Pset_fapl_mpio(h5plist, m_comm, MPI_INFO_NULL));
+    checkH5Err(H5Pset_fapl_mpio(h5plist, m_comm, MPI_INFO_NULL));
 #endif // USE_MPI
 
-		hid_t h5file = H5Fopen(cellNames[0].c_str(), H5F_ACC_RDONLY, h5plist);
-		checkH5Err(h5file);
+    hid_t h5file = H5Fopen(cellNames[0].c_str(), H5F_ACC_RDONLY, h5plist);
+    checkH5Err(h5file);
 
-		// Get cell dataset
-		hid_t h5dataset = H5Dopen(h5file, cellNames[1].c_str(), H5P_DEFAULT);
-		checkH5Err(h5dataset);
+    // Get cell dataset
+    hid_t h5dataset = H5Dopen(h5file, cellNames[1].c_str(), H5P_DEFAULT);
+    checkH5Err(h5dataset);
 
-		// Check the size of cell dataset
-		hid_t h5space = H5Dget_space(h5dataset);
-		checkH5Err(h5space);
-		if (H5Sget_simple_extent_ndims(h5space) != 2)
-			logError() << "Cell dataset must have 2 dimensions";
-		hsize_t dims[2];
-		checkH5Err(H5Sget_simple_extent_dims(h5space, dims, 0L));
-		if (dims[1] != internal::Topology<Topo>::cellvertices())
-			logError() << "Each cell must have" << internal::Topology<Topo>::cellvertices() << "vertices";
+    // Check the size of cell dataset
+    hid_t h5space = H5Dget_space(h5dataset);
+    checkH5Err(h5space);
+    if (H5Sget_simple_extent_ndims(h5space) != 2)
+      logError() << "Cell dataset must have 2 dimensions";
+    hsize_t dims[2];
+    checkH5Err(H5Sget_simple_extent_dims(h5space, dims, 0L));
+    if (dims[1] != internal::Topology<Topo>::cellvertices())
+      logError() << "Each cell must have" << internal::Topology<Topo>::cellvertices() << "vertices";
 
-		logInfo(rank) << "Found" << dims[0] << "cells";
+    logInfo(rank) << "Found" << dims[0] << "cells";
 
-		// Read the cells
-		m_originalTotalSize[0] = dims[0];
-		m_originalSize[0] = (dims[0] + procs - 1) / procs;
-		unsigned long offset = static_cast<unsigned long>(m_originalSize[0]) * rank;
-		m_originalSize[0] = std::min(m_originalSize[0], static_cast<unsigned int>(dims[0] - offset));
+    // Read the cells
+    m_originalTotalSize[0] = dims[0];
+    m_originalSize[0] = (dims[0] + procs - 1) / procs;
+    unsigned long offset = static_cast<unsigned long>(m_originalSize[0]) * rank;
+    m_originalSize[0] = std::min(m_originalSize[0], static_cast<unsigned int>(dims[0] - offset));
 
-		hsize_t start[2] = {offset, 0};
-		hsize_t count[2] = {m_originalSize[0], internal::Topology<Topo>::cellvertices()};
+    hsize_t start[2] = {offset, 0};
+    hsize_t count[2] = {m_originalSize[0], internal::Topology<Topo>::cellvertices()};
 
-		checkH5Err(H5Sselect_hyperslab(h5space, H5S_SELECT_SET, start, 0L, count, 0L));
+    checkH5Err(H5Sselect_hyperslab(h5space, H5S_SELECT_SET, start, 0L, count, 0L));
 
-		hid_t h5memspace = H5Screate_simple(2, count, 0L);
-		checkH5Err(h5memspace);
+    hid_t h5memspace = H5Screate_simple(2, count, 0L);
+    checkH5Err(h5memspace);
 
-		hid_t h5alist = H5Pcreate(H5P_DATASET_XFER);
-		checkH5Err(h5alist);
+    hid_t h5alist = H5Pcreate(H5P_DATASET_XFER);
+    checkH5Err(h5alist);
 #ifdef USE_MPI
-		checkH5Err(H5Pset_dxpl_mpio(h5alist, H5FD_MPIO_COLLECTIVE));
+    checkH5Err(H5Pset_dxpl_mpio(h5alist, H5FD_MPIO_COLLECTIVE));
 #endif // USE_MPI
 
-		m_originalCells = new ocell_t[m_originalSize[0]];
-		checkH5Err(H5Dread(h5dataset, H5T_NATIVE_ULONG, h5memspace, h5space, h5alist, m_originalCells));
+    m_originalCells = new ocell_t[m_originalSize[0]];
+    checkH5Err(H5Dread(h5dataset, H5T_NATIVE_ULONG, h5memspace, h5space, h5alist, m_originalCells));
 
-		// Close cells
-		checkH5Err(H5Sclose(h5space));
-		checkH5Err(H5Sclose(h5memspace));
-		checkH5Err(H5Dclose(h5dataset));
-		checkH5Err(H5Fclose(h5file));
+    // Close cells
+    checkH5Err(H5Sclose(h5space));
+    checkH5Err(H5Sclose(h5memspace));
+    checkH5Err(H5Dclose(h5dataset));
+    checkH5Err(H5Fclose(h5file));
 
-		// Open the vertex file
-		h5file = H5Fopen(vertexNames[0].c_str(), H5F_ACC_RDONLY, h5plist);
-		checkH5Err(h5file);
+    // Open the vertex file
+    h5file = H5Fopen(vertexNames[0].c_str(), H5F_ACC_RDONLY, h5plist);
+    checkH5Err(h5file);
 
-		// Get vertex dataset
-		h5dataset = H5Dopen(h5file, vertexNames[1].c_str(), H5P_DEFAULT);
-		checkH5Err(h5dataset);
+    // Get vertex dataset
+    h5dataset = H5Dopen(h5file, vertexNames[1].c_str(), H5P_DEFAULT);
+    checkH5Err(h5dataset);
 
-		// Check the size of vertex dataset
-		h5space = H5Dget_space(h5dataset);
-		checkH5Err(h5space);
-		if (H5Sget_simple_extent_ndims(h5space) != 2)
-			logError() << "Vertex dataset must have 2 dimensions";
-		checkH5Err(H5Sget_simple_extent_dims(h5space, dims, 0L));
-		if (dims[1] != 3)
-			logError() << "Each vertex must have xyz coordinate";
+    // Check the size of vertex dataset
+    h5space = H5Dget_space(h5dataset);
+    checkH5Err(h5space);
+    if (H5Sget_simple_extent_ndims(h5space) != 2)
+      logError() << "Vertex dataset must have 2 dimensions";
+    checkH5Err(H5Sget_simple_extent_dims(h5space, dims, 0L));
+    if (dims[1] != 3)
+      logError() << "Each vertex must have xyz coordinate";
 
-		logInfo(rank) << "Found" << dims[0] << "vertices";
+    logInfo(rank) << "Found" << dims[0] << "vertices";
 
-		// Read the vertices
-		m_originalTotalSize[1] = dims[0];
-		m_originalSize[1] = (dims[0] + procs - 1) / procs;
-		offset = static_cast<unsigned long>(m_originalSize[1]) * rank;
-		m_originalSize[1] = std::min(m_originalSize[1], static_cast<unsigned int>(dims[0] - offset));
+    // Read the vertices
+    m_originalTotalSize[1] = dims[0];
+    m_originalSize[1] = (dims[0] + procs - 1) / procs;
+    offset = static_cast<unsigned long>(m_originalSize[1]) * rank;
+    m_originalSize[1] = std::min(m_originalSize[1], static_cast<unsigned int>(dims[0] - offset));
 
-		start[0] = offset;
-		count[0] = m_originalSize[1]; count[1] = 3;
+    start[0] = offset;
+    count[0] = m_originalSize[1];
+    count[1] = 3;
 
-		checkH5Err(H5Sselect_hyperslab(h5space, H5S_SELECT_SET, start, 0L, count, 0L));
+    checkH5Err(H5Sselect_hyperslab(h5space, H5S_SELECT_SET, start, 0L, count, 0L));
 
-		h5memspace = H5Screate_simple(2, count, 0L);
-		checkH5Err(h5memspace);
+    h5memspace = H5Screate_simple(2, count, 0L);
+    checkH5Err(h5memspace);
 
-		m_originalVertices = new overtex_t[m_originalSize[1]];
-		checkH5Err(H5Dread(h5dataset, H5T_NATIVE_DOUBLE, h5memspace, h5space, h5alist, m_originalVertices));
+    m_originalVertices = new overtex_t[m_originalSize[1]];
+    checkH5Err(H5Dread(h5dataset, H5T_NATIVE_DOUBLE, h5memspace, h5space, h5alist, m_originalVertices));
 
-		// Close vertices
-		checkH5Err(H5Sclose(h5space));
-		checkH5Err(H5Sclose(h5memspace));
-		checkH5Err(H5Dclose(h5dataset));
-		checkH5Err(H5Fclose(h5file));
+    // Close vertices
+    checkH5Err(H5Sclose(h5space));
+    checkH5Err(H5Sclose(h5memspace));
+    checkH5Err(H5Dclose(h5dataset));
+    checkH5Err(H5Fclose(h5file));
 
-		// Close other H5 stuff
-		checkH5Err(H5Pclose(h5plist));
-		checkH5Err(H5Pclose(h5alist));
-	}
+    // Close other H5 stuff
+    checkH5Err(H5Pclose(h5plist));
+    checkH5Err(H5Pclose(h5alist));
+  }
 
-	void addData(const char* dataName, DataType type)
-	{
-		int rank = 0;
-		int procs = 1;
+  void addData(const char* dataName, DataType type) {
+    int rank = 0;
+    int procs = 1;
 #ifdef USE_MPI
-		MPI_Comm_rank(m_comm, &rank);
-		MPI_Comm_size(m_comm, &procs);
+    MPI_Comm_rank(m_comm, &rank);
+    MPI_Comm_size(m_comm, &procs);
 #endif // USE_MPI
 
-		std::vector<std::string> dataNames = utils::StringUtils::split(dataName, ':');
-		if (dataNames.size() != 2)
-			logError() << "Data name must have the form \"filename:/dataset\"";
+    std::vector<std::string> dataNames = utils::StringUtils::split(dataName, ':');
+    if (dataNames.size() != 2)
+      logError() << "Data name must have the form \"filename:/dataset\"";
 
-		// Open the cell file
-		hid_t h5plist = H5Pcreate(H5P_FILE_ACCESS);
-		checkH5Err(h5plist);
+    // Open the cell file
+    hid_t h5plist = H5Pcreate(H5P_FILE_ACCESS);
+    checkH5Err(h5plist);
 #ifdef USE_MPI
-		checkH5Err(H5Pset_fapl_mpio(h5plist, m_comm, MPI_INFO_NULL));
+    checkH5Err(H5Pset_fapl_mpio(h5plist, m_comm, MPI_INFO_NULL));
 #endif // USE_MPI
 
-		hid_t h5file = H5Fopen(dataNames[0].c_str(), H5F_ACC_RDONLY, h5plist);
-		checkH5Err(h5file);
+    hid_t h5file = H5Fopen(dataNames[0].c_str(), H5F_ACC_RDONLY, h5plist);
+    checkH5Err(h5file);
 
-		unsigned long totalSize = m_originalTotalSize[type];
-		unsigned int localSize = m_originalSize[type];
+    unsigned long totalSize = m_originalTotalSize[type];
+    unsigned int localSize = m_originalSize[type];
 
-		// Get cell dataset
-		hid_t h5dataset = H5Dopen(h5file, dataNames[1].c_str(), H5P_DEFAULT);
-		checkH5Err(h5dataset);
+    // Get cell dataset
+    hid_t h5dataset = H5Dopen(h5file, dataNames[1].c_str(), H5P_DEFAULT);
+    checkH5Err(h5dataset);
 
-		// Check the size of cell dataset
-		hid_t h5space = H5Dget_space(h5dataset);
-		checkH5Err(h5space);
-		if (H5Sget_simple_extent_ndims(h5space) != 1)
-			logError() << "Dataset must have 1 dimension";
-		hsize_t dim;
-		checkH5Err(H5Sget_simple_extent_dims(h5space, &dim, 0L));
-		if (dim != totalSize)
-			logError() << "Dataset has the wrong size";
+    // Check the size of cell dataset
+    hid_t h5space = H5Dget_space(h5dataset);
+    checkH5Err(h5space);
+    if (H5Sget_simple_extent_ndims(h5space) != 1)
+      logError() << "Dataset must have 1 dimension";
+    hsize_t dim;
+    checkH5Err(H5Sget_simple_extent_dims(h5space, &dim, 0L));
+    if (dim != totalSize)
+      logError() << "Dataset has the wrong size";
 
-		// Read the cells
-		unsigned int maxLocalSize = (totalSize + procs - 1) / procs;
-		unsigned long offset = static_cast<unsigned long>(maxLocalSize) * rank;
+    // Read the cells
+    unsigned int maxLocalSize = (totalSize + procs - 1) / procs;
+    unsigned long offset = static_cast<unsigned long>(maxLocalSize) * rank;
 
-		hsize_t start = offset;
-		hsize_t count = localSize;
+    hsize_t start = offset;
+    hsize_t count = localSize;
 
-		checkH5Err(H5Sselect_hyperslab(h5space, H5S_SELECT_SET, &start, 0L, &count, 0L));
+    checkH5Err(H5Sselect_hyperslab(h5space, H5S_SELECT_SET, &start, 0L, &count, 0L));
 
-		hid_t h5memspace = H5Screate_simple(1, &count, 0L);
-		checkH5Err(h5memspace);
+    hid_t h5memspace = H5Screate_simple(1, &count, 0L);
+    checkH5Err(h5memspace);
 
-		hid_t h5alist = H5Pcreate(H5P_DATASET_XFER);
-		checkH5Err(h5alist);
+    hid_t h5alist = H5Pcreate(H5P_DATASET_XFER);
+    checkH5Err(h5alist);
 #ifdef USE_MPI
-		checkH5Err(H5Pset_dxpl_mpio(h5alist, H5FD_MPIO_COLLECTIVE));
+    checkH5Err(H5Pset_dxpl_mpio(h5alist, H5FD_MPIO_COLLECTIVE));
 #endif // USE_MPI
 
-		int* data = new int[localSize];
-		checkH5Err(H5Dread(h5dataset, H5T_NATIVE_INT, h5memspace, h5space, h5alist, data));
+    int* data = new int[localSize];
+    checkH5Err(H5Dread(h5dataset, H5T_NATIVE_INT, h5memspace, h5space, h5alist, data));
 
-		// Close data
-		checkH5Err(H5Sclose(h5space));
-		checkH5Err(H5Sclose(h5memspace));
-		checkH5Err(H5Dclose(h5dataset));
-		checkH5Err(H5Fclose(h5file));
+    // Close data
+    checkH5Err(H5Sclose(h5space));
+    checkH5Err(H5Sclose(h5memspace));
+    checkH5Err(H5Dclose(h5dataset));
+    checkH5Err(H5Fclose(h5file));
 
-		// Close other H5 stuff
-		checkH5Err(H5Pclose(h5plist));
-		checkH5Err(H5Pclose(h5alist));
+    // Close other H5 stuff
+    checkH5Err(H5Pclose(h5plist));
+    checkH5Err(H5Pclose(h5alist));
 
-		switch (type) {
-		case CELL:
-			m_cellData.push_back(data);
-			break;
-		case VERTEX:
-			m_originalVertexData.push_back(data);
-			break;
-		}
-	}
+    switch (type) {
+    case CELL:
+      m_cellData.push_back(data);
+      break;
+    case VERTEX:
+      m_originalVertexData.push_back(data);
+      break;
+    }
+  }
 
-	void partition(int* partition)
-	{
-		int rank = 0;
-		int procs = 1;
+  void partition(int* partition) {
+    int rank = 0;
+    int procs = 1;
 #ifdef USE_MPI
-		MPI_Comm_rank(m_comm, &rank);
-		MPI_Comm_size(m_comm, &procs);
+    MPI_Comm_rank(m_comm, &rank);
+    MPI_Comm_size(m_comm, &procs);
 #endif // USE_MPI
 
-		// Create sorting indices
-		unsigned int* indices = new unsigned int[m_originalSize[0]];
-		for (unsigned int i = 0; i < m_originalSize[0]; i++)
-			indices[i] = i;
+    // Create sorting indices
+    unsigned int* indices = new unsigned int[m_originalSize[0]];
+    for (unsigned int i = 0; i < m_originalSize[0]; i++)
+      indices[i] = i;
 
-		struct PSort
-		{
-			const int * const partition;
+    struct PSort {
+      const int* const partition;
 
-			PSort(const int* partition) : partition(partition)
-			{ }
+      PSort(const int* partition) : partition(partition) {}
 
-			bool operator()(unsigned int i1, unsigned int i2) const
-			{
-				return partition[i1] < partition[i2];
-			}
-		};
-		std::sort(indices, indices+m_originalSize[0], PSort(partition));
+      bool operator()(unsigned int i1, unsigned int i2) const { return partition[i1] < partition[i2]; }
+    };
+    std::sort(indices, indices + m_originalSize[0], PSort(partition));
 
-		// Sort cells
-		ocell_t* newCells = new ocell_t[m_originalSize[0]];
-		for (unsigned int i = 0; i < m_originalSize[0]; i++) {
-			memcpy(newCells[i], m_originalCells[indices[i]], sizeof(ocell_t));
-		}
-		delete [] m_originalCells;
-		m_originalCells = newCells;
+    // Sort cells
+    ocell_t* newCells = new ocell_t[m_originalSize[0]];
+    for (unsigned int i = 0; i < m_originalSize[0]; i++) {
+      memcpy(newCells[i], m_originalCells[indices[i]], sizeof(ocell_t));
+    }
+    delete[] m_originalCells;
+    m_originalCells = newCells;
 
-		// Sort other data
-		for (std::vector<int*>::iterator it = m_cellData.begin();
-				it != m_cellData.end(); ++it) {
-			int* newData = new int[m_originalSize[0]];
-			for (unsigned int i = 0; i < m_originalSize[0]; i++) {
-				newData[i] = (*it)[indices[i]];
-			}
+    // Sort other data
+    for (std::vector<int*>::iterator it = m_cellData.begin(); it != m_cellData.end(); ++it) {
+      int* newData = new int[m_originalSize[0]];
+      for (unsigned int i = 0; i < m_originalSize[0]; i++) {
+        newData[i] = (*it)[indices[i]];
+      }
 
-			delete [] *it;
-			*it = newData;
-		}
+      delete[] * it;
+      *it = newData;
+    }
 
-		delete [] indices;
+    delete[] indices;
 
-		// Compute exchange info
-		int* sendCount = new int[procs];
-		memset(sendCount, 0, procs * sizeof(int));
+    // Compute exchange info
+    int* sendCount = new int[procs];
+    memset(sendCount, 0, procs * sizeof(int));
 
-		for (unsigned int i = 0; i < m_originalSize[0]; i++) {
-			assert(partition[i] < procs);
-			sendCount[partition[i]]++;
-		}
+    for (unsigned int i = 0; i < m_originalSize[0]; i++) {
+      assert(partition[i] < procs);
+      sendCount[partition[i]]++;
+    }
 
-		int* recvCount = new int[procs];
+    int* recvCount = new int[procs];
 #ifdef USE_MPI
-		MPI_Alltoall(sendCount, 1, MPI_INT, recvCount, 1, MPI_INT, m_comm);
-#else // USE_MPI
-		recvCount[0] = sendCount[0];
+    MPI_Alltoall(sendCount, 1, MPI_INT, recvCount, 1, MPI_INT, m_comm);
+#else  // USE_MPI
+    recvCount[0] = sendCount[0];
 #endif // USE_MPI
 
-		int *sDispls = new int[procs];
-		int *rDispls = new int[procs];
-		sDispls[0] = 0;
-		rDispls[0] = 0;
-		for (int i = 1; i < procs; i++) {
-			sDispls[i] = sDispls[i-1] + sendCount[i-1];
-			rDispls[i] = rDispls[i-1] + recvCount[i-1];
-		}
+    int* sDispls = new int[procs];
+    int* rDispls = new int[procs];
+    sDispls[0] = 0;
+    rDispls[0] = 0;
+    for (int i = 1; i < procs; i++) {
+      sDispls[i] = sDispls[i - 1] + sendCount[i - 1];
+      rDispls[i] = rDispls[i - 1] + recvCount[i - 1];
+    }
 
-		m_originalSize[0] = rDispls[procs-1] + recvCount[procs-1];
+    m_originalSize[0] = rDispls[procs - 1] + recvCount[procs - 1];
 
 #ifdef USE_MPI
-		// Exchange the cells
-		MPI_Datatype cellType;
-		MPI_Type_contiguous(internal::Topology<Topo>::cellvertices(), MPI_UNSIGNED_LONG, &cellType);
-		MPI_Type_commit(&cellType);
+    // Exchange the cells
+    MPI_Datatype cellType;
+    MPI_Type_contiguous(internal::Topology<Topo>::cellvertices(), MPI_UNSIGNED_LONG, &cellType);
+    MPI_Type_commit(&cellType);
 
-		newCells = new ocell_t[m_originalSize[0]];
-		MPI_Alltoallv(m_originalCells, sendCount, sDispls, cellType,
-			newCells, recvCount, rDispls, cellType,
-			m_comm);
+    newCells = new ocell_t[m_originalSize[0]];
+    MPI_Alltoallv(m_originalCells, sendCount, sDispls, cellType, newCells, recvCount, rDispls, cellType, m_comm);
 
-		delete [] m_originalCells;
-		m_originalCells = newCells;
+    delete[] m_originalCells;
+    m_originalCells = newCells;
 
-		MPI_Type_free(&cellType);
+    MPI_Type_free(&cellType);
 
-		// Exchange cell data
-		for (std::vector<int*>::iterator it = m_cellData.begin();
-				it != m_cellData.end(); ++it) {
-			int* newData = new int[m_originalSize[0]];
-			MPI_Alltoallv(*it, sendCount, sDispls, MPI_INT,
-				newData, recvCount, rDispls, MPI_INT,
-				m_comm);
+    // Exchange cell data
+    for (std::vector<int*>::iterator it = m_cellData.begin(); it != m_cellData.end(); ++it) {
+      int* newData = new int[m_originalSize[0]];
+      MPI_Alltoallv(*it, sendCount, sDispls, MPI_INT, newData, recvCount, rDispls, MPI_INT, m_comm);
 
-			delete [] *it;
-			*it = newData;
-		}
+      delete[] * it;
+      *it = newData;
+    }
 #endif // USE_MPI
 
-		delete [] sendCount;
-		delete [] recvCount;
-		delete [] sDispls;
-		delete [] rDispls;
-	}
+    delete[] sendCount;
+    delete[] recvCount;
+    delete[] sDispls;
+    delete[] rDispls;
+  }
 
-	void generateMesh()
-	{
-		int rank = 0;
-		int procs = 1;
+  void generateMesh() {
+    int rank = 0;
+    int procs = 1;
 #ifdef USE_MPI
-		MPI_Comm_rank(m_comm, &rank);
-		MPI_Comm_size(m_comm, &procs);
+    MPI_Comm_rank(m_comm, &rank);
+    MPI_Comm_size(m_comm, &procs);
 #endif // USE_MPI
 
-		// Generate a list of vertices we need from other processors
-		unsigned int maxVertices = (m_originalTotalSize[1] + procs - 1) / procs;
+    // Generate a list of vertices we need from other processors
+    unsigned int maxVertices = (m_originalTotalSize[1] + procs - 1) / procs;
 
-		std::unordered_set<unsigned long>* requiredVertexSets = new std::unordered_set<unsigned long>[procs];
-		for (unsigned int i = 0; i < m_originalSize[0]; i++) {
-			for (unsigned int j = 0; j < internal::Topology<Topo>::cellvertices(); j++) {
-				int proc = m_originalCells[i][j] / maxVertices;
-				assert(proc < procs);
+    std::unordered_set<unsigned long>* requiredVertexSets = new std::unordered_set<unsigned long>[procs];
+    for (unsigned int i = 0; i < m_originalSize[0]; i++) {
+      for (unsigned int j = 0; j < internal::Topology<Topo>::cellvertices(); j++) {
+        int proc = m_originalCells[i][j] / maxVertices;
+        assert(proc < procs);
 
-				requiredVertexSets[proc].insert(m_originalCells[i][j]); // Convert to local vid
-			}
-		}
+        requiredVertexSets[proc].insert(m_originalCells[i][j]); // Convert to local vid
+      }
+    }
 
-		// Generate information for requesting vertices
-		unsigned int totalVertices = requiredVertexSets[0].size();
-		for (int i = 1; i < procs; i++)
-			totalVertices += requiredVertexSets[i].size();
+    // Generate information for requesting vertices
+    unsigned int totalVertices = requiredVertexSets[0].size();
+    for (int i = 1; i < procs; i++)
+      totalVertices += requiredVertexSets[i].size();
 
-		int* sendCount = new int[procs];
+    int* sendCount = new int[procs];
 
-		unsigned long* requiredVertices = new unsigned long[totalVertices];
-		unsigned int k = 0;
-		for (int i = 0; i < procs; i++) {
-			sendCount[i] = requiredVertexSets[i].size();
+    unsigned long* requiredVertices = new unsigned long[totalVertices];
+    unsigned int k = 0;
+    for (int i = 0; i < procs; i++) {
+      sendCount[i] = requiredVertexSets[i].size();
 
-			for (std::unordered_set<unsigned long>::const_iterator it = requiredVertexSets[i].begin();
-					it != requiredVertexSets[i].end(); ++it) {
-				assert(k < totalVertices);
-				requiredVertices[k++] = *it;
-			}
-		}
+      for (std::unordered_set<unsigned long>::const_iterator it = requiredVertexSets[i].begin();
+           it != requiredVertexSets[i].end(); ++it) {
+        assert(k < totalVertices);
+        requiredVertices[k++] = *it;
+      }
+    }
 
-		delete [] requiredVertexSets;
+    delete[] requiredVertexSets;
 
-		// Exchange required vertex information
-		int* recvCount = new int[procs];
+    // Exchange required vertex information
+    int* recvCount = new int[procs];
 #ifdef USE_MPI
-		MPI_Alltoall(sendCount, 1, MPI_INT, recvCount, 1, MPI_INT, m_comm);
-#else // USE_MPI
-		recvCount[0] = sendCount[0];
+    MPI_Alltoall(sendCount, 1, MPI_INT, recvCount, 1, MPI_INT, m_comm);
+#else  // USE_MPI
+    recvCount[0] = sendCount[0];
 #endif // USE_MPI
 
-		int *sDispls = new int[procs];
-		int *rDispls = new int[procs];
-		sDispls[0] = 0;
-		rDispls[0] = 0;
-		for (int i = 1; i < procs; i++) {
-			sDispls[i] = sDispls[i-1] + sendCount[i-1];
-			rDispls[i] = rDispls[i-1] + recvCount[i-1];
-		}
+    int* sDispls = new int[procs];
+    int* rDispls = new int[procs];
+    sDispls[0] = 0;
+    rDispls[0] = 0;
+    for (int i = 1; i < procs; i++) {
+      sDispls[i] = sDispls[i - 1] + sendCount[i - 1];
+      rDispls[i] = rDispls[i - 1] + recvCount[i - 1];
+    }
 
-		unsigned int totalRecv = rDispls[procs-1] + recvCount[procs-1];
+    unsigned int totalRecv = rDispls[procs - 1] + recvCount[procs - 1];
 
-		unsigned long* distribVertexIds = new unsigned long[totalRecv];
+    unsigned long* distribVertexIds = new unsigned long[totalRecv];
 #ifdef USE_MPI
-		MPI_Alltoallv(requiredVertices, sendCount, sDispls, MPI_UNSIGNED_LONG,
-			distribVertexIds, recvCount, rDispls, MPI_UNSIGNED_LONG,
-			m_comm);
+    MPI_Alltoallv(requiredVertices, sendCount, sDispls, MPI_UNSIGNED_LONG, distribVertexIds, recvCount, rDispls,
+                  MPI_UNSIGNED_LONG, m_comm);
 #endif // USE_MPI
 
-		// Send back vertex coordinates (an other data)
-		overtex_t* distribVertices = new overtex_t[totalRecv];
-		std::vector<int*> distribData;
-		distribData.resize(m_originalVertexData.size());
-		for (unsigned int i = 0; i < m_originalVertexData.size(); i++)
-			distribData[i] = new int[totalRecv];
-		std::vector<int>* sharedRanks = new std::vector<int>[m_originalSize[1]];
-		k = 0;
-		for (int i = 0; i < procs; i++) {
-			for (int j = 0; j < recvCount[i]; j++) {
-				assert(k < totalRecv);
-				distribVertexIds[k] %= maxVertices; // Map to local vertex id
-				assert(distribVertexIds[k] < m_originalSize[1]);
-				memcpy(distribVertices[k], m_originalVertices[distribVertexIds[k]], sizeof(overtex_t));
+    // Send back vertex coordinates (an other data)
+    overtex_t* distribVertices = new overtex_t[totalRecv];
+    std::vector<int*> distribData;
+    distribData.resize(m_originalVertexData.size());
+    for (unsigned int i = 0; i < m_originalVertexData.size(); i++)
+      distribData[i] = new int[totalRecv];
+    std::vector<int>* sharedRanks = new std::vector<int>[m_originalSize[1]];
+    k = 0;
+    for (int i = 0; i < procs; i++) {
+      for (int j = 0; j < recvCount[i]; j++) {
+        assert(k < totalRecv);
+        distribVertexIds[k] %= maxVertices; // Map to local vertex id
+        assert(distribVertexIds[k] < m_originalSize[1]);
+        memcpy(distribVertices[k], m_originalVertices[distribVertexIds[k]], sizeof(overtex_t));
 
-				// Handle other vertex data
-				for (unsigned int l = 0; l < m_originalVertexData.size(); l++)
-					distribData[l][k] = m_originalVertexData[l][distribVertexIds[k]];
+        // Handle other vertex data
+        for (unsigned int l = 0; l < m_originalVertexData.size(); l++)
+          distribData[l][k] = m_originalVertexData[l][distribVertexIds[k]];
 
-				// Save all ranks for each vertex
-				sharedRanks[distribVertexIds[k]].push_back(i);
+        // Save all ranks for each vertex
+        sharedRanks[distribVertexIds[k]].push_back(i);
 
-				k++;
-			}
-		}
+        k++;
+      }
+    }
 
-		overtex_t* recvVertices = new overtex_t[totalVertices];
+    overtex_t* recvVertices = new overtex_t[totalVertices];
 
-		for (std::vector<int*>::iterator it = m_vertexData.begin();
-				it != m_vertexData.end(); ++it) {
-			delete [] *it;
-		}
-		m_vertexData.resize(m_originalVertexData.size());
-		for (std::vector<int*>::iterator it = m_vertexData.begin();
-				it != m_vertexData.end(); ++it) {
-			*it = new int[totalVertices];
-		}
+    for (std::vector<int*>::iterator it = m_vertexData.begin(); it != m_vertexData.end(); ++it) {
+      delete[] * it;
+    }
+    m_vertexData.resize(m_originalVertexData.size());
+    for (std::vector<int*>::iterator it = m_vertexData.begin(); it != m_vertexData.end(); ++it) {
+      *it = new int[totalVertices];
+    }
 #ifdef USE_MPI
-		MPI_Datatype vertexType;
-		MPI_Type_contiguous(3, MPI_DOUBLE, &vertexType);
-		MPI_Type_commit(&vertexType);
+    MPI_Datatype vertexType;
+    MPI_Type_contiguous(3, MPI_DOUBLE, &vertexType);
+    MPI_Type_commit(&vertexType);
 
-		MPI_Alltoallv(distribVertices, recvCount, rDispls, vertexType,
-			recvVertices, sendCount, sDispls, vertexType,
-			m_comm);
+    MPI_Alltoallv(distribVertices, recvCount, rDispls, vertexType, recvVertices, sendCount, sDispls, vertexType,
+                  m_comm);
 
-		MPI_Type_free(&vertexType);
+    MPI_Type_free(&vertexType);
 
-		for (unsigned int i = 0; i < m_originalVertexData.size(); i++) {
-			MPI_Alltoallv(distribData[i], recvCount, rDispls, MPI_INT,
-				m_vertexData[i], sendCount, sDispls, MPI_INT,
-				m_comm);
-		}
+    for (unsigned int i = 0; i < m_originalVertexData.size(); i++) {
+      MPI_Alltoallv(distribData[i], recvCount, rDispls, MPI_INT, m_vertexData[i], sendCount, sDispls, MPI_INT, m_comm);
+    }
 #endif // USE_MPI
 
-		delete [] distribVertices;
-		for (std::vector<int*>::iterator it = distribData.begin();
-				it != distribData.end(); ++it) {
-			delete [] *it;
-		}
-		distribData.clear();
+    delete[] distribVertices;
+    for (std::vector<int*>::iterator it = distribData.begin(); it != distribData.end(); ++it) {
+      delete[] * it;
+    }
+    distribData.clear();
 
-		// Send back the number of shared ranks for each vertex
-		unsigned int* distNsharedRanks = new unsigned int[totalRecv];
-		unsigned int distTotalSharedRanks = 0;
-		for (unsigned int i = 0; i < totalRecv; i++) {
-			assert(distribVertexIds[i] < m_originalSize[1]);
-			distNsharedRanks[i] = sharedRanks[distribVertexIds[i]].size();
-			distTotalSharedRanks += distNsharedRanks[i];
-		}
+    // Send back the number of shared ranks for each vertex
+    unsigned int* distNsharedRanks = new unsigned int[totalRecv];
+    unsigned int distTotalSharedRanks = 0;
+    for (unsigned int i = 0; i < totalRecv; i++) {
+      assert(distribVertexIds[i] < m_originalSize[1]);
+      distNsharedRanks[i] = sharedRanks[distribVertexIds[i]].size();
+      distTotalSharedRanks += distNsharedRanks[i];
+    }
 
-		unsigned int* recvNsharedRanks = new unsigned int[totalVertices];
+    unsigned int* recvNsharedRanks = new unsigned int[totalVertices];
 #ifdef USE_MPI
-		MPI_Alltoallv(distNsharedRanks, recvCount, rDispls, MPI_UNSIGNED,
-			recvNsharedRanks, sendCount, sDispls, MPI_UNSIGNED,
-			m_comm);
+    MPI_Alltoallv(distNsharedRanks, recvCount, rDispls, MPI_UNSIGNED, recvNsharedRanks, sendCount, sDispls,
+                  MPI_UNSIGNED, m_comm);
 #endif // USE_MPI
 
-		delete [] distNsharedRanks;
+    delete[] distNsharedRanks;
 
-		// Setup buffers for exchanging shared ranks
-		int* sharedSendCount = new int[procs];
-		memset(sharedSendCount, 0, procs * sizeof(int));
+    // Setup buffers for exchanging shared ranks
+    int* sharedSendCount = new int[procs];
+    memset(sharedSendCount, 0, procs * sizeof(int));
 
-		int* distSharedRanks = new int[distTotalSharedRanks];
-		k = 0;
-		unsigned int l = 0;
-		for (int i = 0; i < procs; i++) {
-			for (int j = 0; j < recvCount[i]; j++) {
-				assert(k < totalRecv);
-				assert(l + sharedRanks[distribVertexIds[k]].size() <= distTotalSharedRanks);
-				memcpy(&distSharedRanks[l], &sharedRanks[distribVertexIds[k]][0], sharedRanks[distribVertexIds[k]].size() * sizeof(int));
-				l += sharedRanks[distribVertexIds[k]].size();
+    int* distSharedRanks = new int[distTotalSharedRanks];
+    k = 0;
+    unsigned int l = 0;
+    for (int i = 0; i < procs; i++) {
+      for (int j = 0; j < recvCount[i]; j++) {
+        assert(k < totalRecv);
+        assert(l + sharedRanks[distribVertexIds[k]].size() <= distTotalSharedRanks);
+        memcpy(&distSharedRanks[l], &sharedRanks[distribVertexIds[k]][0],
+               sharedRanks[distribVertexIds[k]].size() * sizeof(int));
+        l += sharedRanks[distribVertexIds[k]].size();
 
-				sharedSendCount[i] += sharedRanks[distribVertexIds[k]].size();
+        sharedSendCount[i] += sharedRanks[distribVertexIds[k]].size();
 
-				k++;
-			}
-		}
+        k++;
+      }
+    }
 
-		delete [] distribVertexIds;
-		delete [] sharedRanks;
-		delete [] recvCount;
+    delete[] distribVertexIds;
+    delete[] sharedRanks;
+    delete[] recvCount;
 
-		int* sharedRecvCount = new int[procs];
-		memset(sharedRecvCount, 0, procs * sizeof(int));
+    int* sharedRecvCount = new int[procs];
+    memset(sharedRecvCount, 0, procs * sizeof(int));
 
-		unsigned int recvTotalSharedRanks = 0;
-		k = 0;
-		for (int i = 0; i < procs; i++) {
-			for (int j = 0; j < sendCount[i]; j++) {
-				assert(k < totalVertices);
-				recvTotalSharedRanks += recvNsharedRanks[k];
-				sharedRecvCount[i] += recvNsharedRanks[k];
+    unsigned int recvTotalSharedRanks = 0;
+    k = 0;
+    for (int i = 0; i < procs; i++) {
+      for (int j = 0; j < sendCount[i]; j++) {
+        assert(k < totalVertices);
+        recvTotalSharedRanks += recvNsharedRanks[k];
+        sharedRecvCount[i] += recvNsharedRanks[k];
 
-				k++;
-			}
-		}
+        k++;
+      }
+    }
 
-		delete [] sendCount;
+    delete[] sendCount;
 
-		int* recvSharedRanks = new int[recvTotalSharedRanks];
+    int* recvSharedRanks = new int[recvTotalSharedRanks];
 
-		sDispls[0] = 0;
-		rDispls[0] = 0;
-		for (int i = 1; i < procs; i++) {
-			sDispls[i] = sDispls[i-1] + sharedSendCount[i-1];
-			rDispls[i] = rDispls[i-1] + sharedRecvCount[i-1];
-		}
+    sDispls[0] = 0;
+    rDispls[0] = 0;
+    for (int i = 1; i < procs; i++) {
+      sDispls[i] = sDispls[i - 1] + sharedSendCount[i - 1];
+      rDispls[i] = rDispls[i - 1] + sharedRecvCount[i - 1];
+    }
 
 #ifdef USE_MPI
-		MPI_Alltoallv(distSharedRanks, sharedSendCount, sDispls, MPI_INT,
-			recvSharedRanks, sharedRecvCount, rDispls, MPI_INT,
-			m_comm);
+    MPI_Alltoallv(distSharedRanks, sharedSendCount, sDispls, MPI_INT, recvSharedRanks, sharedRecvCount, rDispls,
+                  MPI_INT, m_comm);
 #endif // USE_MPI
 
-		delete [] distSharedRanks;
-		delete [] sharedSendCount;
-		delete [] sharedRecvCount;
-		delete [] sDispls;
-		delete [] rDispls;
+    delete[] distSharedRanks;
+    delete[] sharedSendCount;
+    delete[] sharedRecvCount;
+    delete[] sDispls;
+    delete[] rDispls;
 
-		// Generate the vertex array
-		m_vertices.resize(totalVertices);
+    // Generate the vertex array
+    m_vertices.resize(totalVertices);
 
-		k = 0;
-		for (unsigned int i = 0; i < totalVertices; i++) {
-			m_vertices[i].m_gid = requiredVertices[i];
-			memcpy(m_vertices[i].m_coordinate, recvVertices[i], sizeof(overtex_t));
-			m_vertices[i].m_sharedRanks.resize(recvNsharedRanks[i]-1);
-			unsigned int l = 0;
-			for (unsigned int j = 0; j < recvNsharedRanks[i]; j++) {
-				if (recvSharedRanks[k] != rank)
-					m_vertices[i].m_sharedRanks[l++] = recvSharedRanks[k];
-				k++;
-			}
-			std::sort(m_vertices[i].m_sharedRanks.begin(), m_vertices[i].m_sharedRanks.end());
-		}
+    k = 0;
+    for (unsigned int i = 0; i < totalVertices; i++) {
+      m_vertices[i].m_gid = requiredVertices[i];
+      memcpy(m_vertices[i].m_coordinate, recvVertices[i], sizeof(overtex_t));
+      m_vertices[i].m_sharedRanks.resize(recvNsharedRanks[i] - 1);
+      unsigned int l = 0;
+      for (unsigned int j = 0; j < recvNsharedRanks[i]; j++) {
+        if (recvSharedRanks[k] != rank)
+          m_vertices[i].m_sharedRanks[l++] = recvSharedRanks[k];
+        k++;
+      }
+      std::sort(m_vertices[i].m_sharedRanks.begin(), m_vertices[i].m_sharedRanks.end());
+    }
 
-		delete [] requiredVertices;
-		delete [] recvVertices;
-		delete [] recvSharedRanks;
-		delete [] recvNsharedRanks;
+    delete[] requiredVertices;
+    delete[] recvVertices;
+    delete[] recvSharedRanks;
+    delete[] recvNsharedRanks;
 
-		// Construct to g2l map for the vertices
-		constructG2L(m_vertices, m_verticesg2l);
+    // Construct to g2l map for the vertices
+    constructG2L(m_vertices, m_verticesg2l);
 
-		// Create the cell, face and edge list
-		m_cells.resize(m_originalSize[0]);
-		m_v2f.clear();
-		m_faces.clear();
-		m_v2e.clear();
+    // Create the cell, face and edge list
+    m_cells.resize(m_originalSize[0]);
+    m_v2f.clear();
+    m_faces.clear();
+    m_v2e.clear();
 
-		unsigned long cellOffset = m_originalSize[0];
+    unsigned long cellOffset = m_originalSize[0];
 #ifdef USE_MPI
-		MPI_Scan(MPI_IN_PLACE, &cellOffset, 1, MPI_UNSIGNED_LONG, MPI_SUM, m_comm);
+    MPI_Scan(MPI_IN_PLACE, &cellOffset, 1, MPI_UNSIGNED_LONG, MPI_SUM, m_comm);
 #endif // USE_MPI
-		cellOffset -= m_originalSize[0];
+    cellOffset -= m_originalSize[0];
 
-		std::vector<std::set<unsigned int> > edgeUpward;
-		std::set<unsigned int>* vertexUpward = new std::set<unsigned int>[m_vertices.size()];
+    std::vector<std::set<unsigned int>> edgeUpward;
+    std::set<unsigned int>* vertexUpward = new std::set<unsigned int>[m_vertices.size()];
 
-		for (unsigned int i = 0; i < m_originalSize[0]; i++) {
-			m_cells[i].m_gid = i + cellOffset;
+    for (unsigned int i = 0; i < m_originalSize[0]; i++) {
+      m_cells[i].m_gid = i + cellOffset;
 
-			for (unsigned int j = 0; j < internal::Topology<Topo>::cellvertices(); j++)
-				m_cells[i].m_vertices[j] = m_verticesg2l[m_originalCells[i][j]];
+      for (unsigned int j = 0; j < internal::Topology<Topo>::cellvertices(); j++)
+        m_cells[i].m_vertices[j] = m_verticesg2l[m_originalCells[i][j]];
 
-			// TODO adapt for hex
+      // TODO adapt for hex
 
-			// Faces
-			unsigned int v[internal::Topology<Topo>::facevertices()];
-			unsigned int faces[internal::Topology<Topo>::cellfaces()];
-			v[0] = m_cells[i].m_vertices[1];
-			v[1] = m_cells[i].m_vertices[0];
-			v[2] = m_cells[i].m_vertices[2];
-			faces[0] = addFace(m_v2f.add(v), i);
-			v[0] = m_cells[i].m_vertices[0];
-			v[1] = m_cells[i].m_vertices[1];
-			v[2] = m_cells[i].m_vertices[3];
-			faces[1] = addFace(m_v2f.add(v), i);
-			v[0] = m_cells[i].m_vertices[1];
-			v[1] = m_cells[i].m_vertices[2];
-			v[2] = m_cells[i].m_vertices[3];
-			faces[2] = addFace(m_v2f.add(v), i);
-			v[0] = m_cells[i].m_vertices[2];
-			v[1] = m_cells[i].m_vertices[0];
-			v[2] = m_cells[i].m_vertices[3];
-			faces[3] = addFace(m_v2f.add(v), i);
+      // Faces
+      unsigned int v[internal::Topology<Topo>::facevertices()];
+      unsigned int faces[internal::Topology<Topo>::cellfaces()];
+      v[0] = m_cells[i].m_vertices[1];
+      v[1] = m_cells[i].m_vertices[0];
+      v[2] = m_cells[i].m_vertices[2];
+      faces[0] = addFace(m_v2f.add(v), i);
+      v[0] = m_cells[i].m_vertices[0];
+      v[1] = m_cells[i].m_vertices[1];
+      v[2] = m_cells[i].m_vertices[3];
+      faces[1] = addFace(m_v2f.add(v), i);
+      v[0] = m_cells[i].m_vertices[1];
+      v[1] = m_cells[i].m_vertices[2];
+      v[2] = m_cells[i].m_vertices[3];
+      faces[2] = addFace(m_v2f.add(v), i);
+      v[0] = m_cells[i].m_vertices[2];
+      v[1] = m_cells[i].m_vertices[0];
+      v[2] = m_cells[i].m_vertices[3];
+      faces[3] = addFace(m_v2f.add(v), i);
 
-			// Edges
-			unsigned int edges[internal::Topology<Topo>::celledges()];
-			v[0] = m_cells[i].m_vertices[0];
-			v[1] = m_cells[i].m_vertices[1];
-			edges[0] = addEdge(edgeUpward, m_v2e.add(v), faces[0], faces[1]);
-			v[0] = m_cells[i].m_vertices[1];
-			v[1] = m_cells[i].m_vertices[2];
-			edges[1] = addEdge(edgeUpward, m_v2e.add(v), faces[0], faces[2]);
-			v[0] = m_cells[i].m_vertices[2];
-			v[1] = m_cells[i].m_vertices[0];
-			edges[2] = addEdge(edgeUpward, m_v2e.add(v), faces[0], faces[3]);
-			v[0] = m_cells[i].m_vertices[0];
-			v[1] = m_cells[i].m_vertices[3];
-			edges[3] = addEdge(edgeUpward, m_v2e.add(v), faces[1], faces[3]);
-			v[0] = m_cells[i].m_vertices[1];
-			v[1] = m_cells[i].m_vertices[3];
-			edges[4] = addEdge(edgeUpward, m_v2e.add(v), faces[1], faces[2]);
-			v[0] = m_cells[i].m_vertices[2];
-			v[1] = m_cells[i].m_vertices[3];
-			edges[5] = addEdge(edgeUpward, m_v2e.add(v), faces[2], faces[3]);
+      // Edges
+      unsigned int edges[internal::Topology<Topo>::celledges()];
+      v[0] = m_cells[i].m_vertices[0];
+      v[1] = m_cells[i].m_vertices[1];
+      edges[0] = addEdge(edgeUpward, m_v2e.add(v), faces[0], faces[1]);
+      v[0] = m_cells[i].m_vertices[1];
+      v[1] = m_cells[i].m_vertices[2];
+      edges[1] = addEdge(edgeUpward, m_v2e.add(v), faces[0], faces[2]);
+      v[0] = m_cells[i].m_vertices[2];
+      v[1] = m_cells[i].m_vertices[0];
+      edges[2] = addEdge(edgeUpward, m_v2e.add(v), faces[0], faces[3]);
+      v[0] = m_cells[i].m_vertices[0];
+      v[1] = m_cells[i].m_vertices[3];
+      edges[3] = addEdge(edgeUpward, m_v2e.add(v), faces[1], faces[3]);
+      v[0] = m_cells[i].m_vertices[1];
+      v[1] = m_cells[i].m_vertices[3];
+      edges[4] = addEdge(edgeUpward, m_v2e.add(v), faces[1], faces[2]);
+      v[0] = m_cells[i].m_vertices[2];
+      v[1] = m_cells[i].m_vertices[3];
+      edges[5] = addEdge(edgeUpward, m_v2e.add(v), faces[2], faces[3]);
 
-			// Vertices (upward information)
-			vertexUpward[m_cells[i].m_vertices[0]].insert(edges[0]);
-			vertexUpward[m_cells[i].m_vertices[0]].insert(edges[2]);
-			vertexUpward[m_cells[i].m_vertices[0]].insert(edges[3]);
-			vertexUpward[m_cells[i].m_vertices[1]].insert(edges[0]);
-			vertexUpward[m_cells[i].m_vertices[1]].insert(edges[1]);
-			vertexUpward[m_cells[i].m_vertices[1]].insert(edges[4]);
-			vertexUpward[m_cells[i].m_vertices[2]].insert(edges[1]);
-			vertexUpward[m_cells[i].m_vertices[2]].insert(edges[2]);
-			vertexUpward[m_cells[i].m_vertices[2]].insert(edges[5]);
-			vertexUpward[m_cells[i].m_vertices[3]].insert(edges[3]);
-			vertexUpward[m_cells[i].m_vertices[3]].insert(edges[4]);
-			vertexUpward[m_cells[i].m_vertices[3]].insert(edges[5]);
-		}
+      // Vertices (upward information)
+      vertexUpward[m_cells[i].m_vertices[0]].insert(edges[0]);
+      vertexUpward[m_cells[i].m_vertices[0]].insert(edges[2]);
+      vertexUpward[m_cells[i].m_vertices[0]].insert(edges[3]);
+      vertexUpward[m_cells[i].m_vertices[1]].insert(edges[0]);
+      vertexUpward[m_cells[i].m_vertices[1]].insert(edges[1]);
+      vertexUpward[m_cells[i].m_vertices[1]].insert(edges[4]);
+      vertexUpward[m_cells[i].m_vertices[2]].insert(edges[1]);
+      vertexUpward[m_cells[i].m_vertices[2]].insert(edges[2]);
+      vertexUpward[m_cells[i].m_vertices[2]].insert(edges[5]);
+      vertexUpward[m_cells[i].m_vertices[3]].insert(edges[3]);
+      vertexUpward[m_cells[i].m_vertices[3]].insert(edges[4]);
+      vertexUpward[m_cells[i].m_vertices[3]].insert(edges[5]);
+    }
 
-		// Create edges
-		m_edges.clear();
-		m_edges.resize(edgeUpward.size());
-		for (unsigned int i = 0; i < m_edges.size(); i++) {
-			assert(m_edges[i].m_upward.empty());
-			m_edges[i].m_upward.resize(edgeUpward[i].size());
-			unsigned int j = 0;
-			for (std::set<unsigned int>::const_iterator it = edgeUpward[i].begin();
-					it != edgeUpward[i].end(); ++it, j++) {
-				m_edges[i].m_upward[j] = *it;
-			}
-		}
-		edgeUpward.clear(); // Free memory
+    // Create edges
+    m_edges.clear();
+    m_edges.resize(edgeUpward.size());
+    for (unsigned int i = 0; i < m_edges.size(); i++) {
+      assert(m_edges[i].m_upward.empty());
+      m_edges[i].m_upward.resize(edgeUpward[i].size());
+      unsigned int j = 0;
+      for (std::set<unsigned int>::const_iterator it = edgeUpward[i].begin(); it != edgeUpward[i].end(); ++it, j++) {
+        m_edges[i].m_upward[j] = *it;
+      }
+    }
+    edgeUpward.clear(); // Free memory
 
-		// Set vertex upward information
-		for (unsigned int i = 0; i < m_vertices.size(); i++) {
-			m_vertices[i].m_upward.resize(vertexUpward[i].size());
-			unsigned int j = 0;
-			for (std::set<unsigned int>::const_iterator it = vertexUpward[i].begin();
-					it != vertexUpward[i].end(); ++it, j++) {
-				m_vertices[i].m_upward[j] = *it;
-			}
-		}
-		delete [] vertexUpward;
+    // Set vertex upward information
+    for (unsigned int i = 0; i < m_vertices.size(); i++) {
+      m_vertices[i].m_upward.resize(vertexUpward[i].size());
+      unsigned int j = 0;
+      for (std::set<unsigned int>::const_iterator it = vertexUpward[i].begin(); it != vertexUpward[i].end();
+           ++it, j++) {
+        m_vertices[i].m_upward[j] = *it;
+      }
+    }
+    delete[] vertexUpward;
 
-		// Generate shared information and global ids for edges
-		generatedSharedAndGID<edge_t, vertex_t, 2>(m_edges, m_vertices);
+    // Generate shared information and global ids for edges
+    generatedSharedAndGID<edge_t, vertex_t, 2>(m_edges, m_vertices);
 
-		// Generate shared information and global ids for faces
-		generatedSharedAndGID<face_t, edge_t, internal::Topology<Topo>::faceedges()>(m_faces, m_edges);
-	}
+    // Generate shared information and global ids for faces
+    generatedSharedAndGID<face_t, edge_t, internal::Topology<Topo>::faceedges()>(m_faces, m_edges);
+  }
 
-	/**
-	 * @return The number of original cells on this rank
-	 *
-	 * @note This value can change when {@link partition()} is called
-	 */
-	unsigned int numOriginalCells() const
-	{
-		return m_originalSize[0];
-	}
+  /**
+   * @return The number of original cells on this rank
+   *
+   * @note This value can change when {@link partition()} is called
+   */
+  unsigned int numOriginalCells() const { return m_originalSize[0]; }
 
-	/**
-	 * @return The number of original vertices on this rank
-	 */
-	unsigned int numOriginalVertices() const
-	{
-		return m_originalSize[1];
-	}
+  /**
+   * @return The number of original vertices on this rank
+   */
+  unsigned int numOriginalVertices() const { return m_originalSize[1]; }
 
-	/**
-	 * @return The original cells on this rank
-	 *
-	 * @note The pointer gets invalid when {@link partition()} is called
-	 */
-	const ocell_t* originalCells() const
-	{
-		return m_originalCells;
-	}
+  /**
+   * @return The original cells on this rank
+   *
+   * @note The pointer gets invalid when {@link partition()} is called
+   */
+  const ocell_t* originalCells() const { return m_originalCells; }
 
-	/**
-	 * @return The original vertices on this rank
-	 */
-	const overtex_t* originalVertices() const
-	{
-		return m_originalVertices;
-	}
+  /**
+   * @return The original vertices on this rank
+   */
+  const overtex_t* originalVertices() const { return m_originalVertices; }
 
-	/**
-	 * @return Original user cell data
-	 */
-	const int* originalCellData(unsigned int index) const
-	{
-		return cellData(index); // This is the same
-	}
+  /**
+   * @return Original user cell data
+   */
+  const int* originalCellData(unsigned int index) const {
+    return cellData(index); // This is the same
+  }
 
-	/**
-	 * @return Original user vertex data
-	 */
-	const int* originalVertexData(unsigned int index) const
-	{
-		return m_originalVertexData[index];
-	}
+  /**
+   * @return Original user vertex data
+   */
+  const int* originalVertexData(unsigned int index) const { return m_originalVertexData[index]; }
 
-	/**
-	 * @return The cells of the mesh
-	 */
-	const std::vector<cell_t>& cells() const
-	{
-		return m_cells;
-	}
+  /**
+   * @return The cells of the mesh
+   */
+  const std::vector<cell_t>& cells() const { return m_cells; }
 
-	/**
-	 * @return The faces of the mesh
-	 */
-	const std::vector<face_t>& faces() const
-	{
-		return m_faces;
-	}
+  /**
+   * @return The faces of the mesh
+   */
+  const std::vector<face_t>& faces() const { return m_faces; }
 
-	/**
-	 * @return The edges of the mesh
-	 */
-	const std::vector<edge_t>& edges() const
-	{
-		return m_edges;
-	}
+  /**
+   * @return The edges of the mesh
+   */
+  const std::vector<edge_t>& edges() const { return m_edges; }
 
-	/**
-	 * @return The vertices of the mesh
-	 */
-	const std::vector<vertex_t>& vertices() const
-	{
-		return m_vertices;
-	}
+  /**
+   * @return The vertices of the mesh
+   */
+  const std::vector<vertex_t>& vertices() const { return m_vertices; }
 
-	/**
-	 * @return User cell data
-	 */
-	const int* cellData(unsigned int index) const
-	{
-		return m_cellData[index];
-	}
+  /**
+   * @return User cell data
+   */
+  const int* cellData(unsigned int index) const { return m_cellData[index]; }
 
-	/**
-	 * @return User vertex data
-	 */
-	const int* vertexData(unsigned int index) const
-	{
-		return m_vertexData[index];
-	}
+  /**
+   * @return User vertex data
+   */
+  const int* vertexData(unsigned int index) const { return m_vertexData[index]; }
 
-	/**
-	 * @param vertexIds A list of local vertex ids
-	 * @return The local face id for the given set of vertices or <code>-1</code> if
-	 *  the face does not exist
-	 */
-	int faceByVertices(unsigned int vertexIds[internal::Topology<Topo>::facevertices()]) const
-	{
-		return m_v2f.find(vertexIds);
-	}
+  /**
+   * @param vertexIds A list of local vertex ids
+   * @return The local face id for the given set of vertices or <code>-1</code> if
+   *  the face does not exist
+   */
+  int faceByVertices(unsigned int vertexIds[internal::Topology<Topo>::facevertices()]) const {
+    return m_v2f.find(vertexIds);
+  }
 
-private:
-	/**
-	 * Add a face but only if it does not exist yet
-	 *
-	 * @param lid The local id of the face
-	 * @param plid The local id of the parent
-	 * @return The local id of the face
-	 */
-	unsigned int addFace(unsigned int lid, unsigned int plid)
-	{
-		if (lid < m_faces.size()) {
-			// Update an old face
-			assert(m_faces[lid].m_upward[1] == -1);
-			m_faces[lid].m_upward[1] = plid;
-			if (m_faces[lid].m_upward[1] < m_faces[lid].m_upward[0])
-				std::swap(m_faces[lid].m_upward[0], m_faces[lid].m_upward[1]);
-		} else {
-			// New face
-			assert(lid == m_faces.size());
+  private:
+  /**
+   * Add a face but only if it does not exist yet
+   *
+   * @param lid The local id of the face
+   * @param plid The local id of the parent
+   * @return The local id of the face
+   */
+  unsigned int addFace(unsigned int lid, unsigned int plid) {
+    if (lid < m_faces.size()) {
+      // Update an old face
+      assert(m_faces[lid].m_upward[1] == -1);
+      m_faces[lid].m_upward[1] = plid;
+      if (m_faces[lid].m_upward[1] < m_faces[lid].m_upward[0])
+        std::swap(m_faces[lid].m_upward[0], m_faces[lid].m_upward[1]);
+    } else {
+      // New face
+      assert(lid == m_faces.size());
 
-			face_t face;
-			face.m_upward[0] = plid;
-			face.m_upward[1] = -1;
-			m_faces.push_back(face);
-		}
+      face_t face;
+      face.m_upward[0] = plid;
+      face.m_upward[1] = -1;
+      m_faces.push_back(face);
+    }
 
-		return lid;
-	}
+    return lid;
+  }
 
-	/**
-	 * Generates the shared information and global ids from the downward elements
-	 *
-	 * @param elements The elements for which the data should be generated
-	 * @param down The downward elements
-	 * @tparam N The number of downward elements
-	 */
-	template<typename E, typename D, unsigned int N>
-	void generatedSharedAndGID(std::vector<E> &elements, const std::vector<D> &down)
-	{
+  /**
+   * Generates the shared information and global ids from the downward elements
+   *
+   * @param elements The elements for which the data should be generated
+   * @param down The downward elements
+   * @tparam N The number of downward elements
+   */
+  template <typename E, typename D, unsigned int N>
+  void generatedSharedAndGID(std::vector<E>& elements, const std::vector<D>& down) {
 #ifdef USE_MPI
-		// Collect all shared ranks for each element and downward gids
-		const std::vector<int> ** allShared = new const std::vector<int>*[elements.size() * N];
-		memset(allShared, 0, elements.size() * N * sizeof(std::vector<int>*));
-		unsigned long* downward = new unsigned long[elements.size() * N];
-		unsigned int* downPos = new unsigned int[elements.size()];
-		memset(downPos, 0, elements.size() * sizeof(unsigned int));
+    // Collect all shared ranks for each element and downward gids
+    const std::vector<int>** allShared = new const std::vector<int>*[elements.size() * N];
+    memset(allShared, 0, elements.size() * N * sizeof(std::vector<int>*));
+    unsigned long* downward = new unsigned long[elements.size() * N];
+    unsigned int* downPos = new unsigned int[elements.size()];
+    memset(downPos, 0, elements.size() * sizeof(unsigned int));
 
-		for (typename std::vector<D>::const_iterator it = down.begin();
-				it != down.end(); ++it) {
-			for (std::vector<int>::const_iterator it2 = it->m_upward.begin();
-					it2 != it->m_upward.end(); ++it2) {
-				assert(downPos[*it2] < N);
-				allShared[*it2 * N + downPos[*it2]] = &it->m_sharedRanks;
-				downward[*it2 * N + downPos[*it2]] = it->m_gid;
-				downPos[*it2]++;
-			}
-		}
+    for (typename std::vector<D>::const_iterator it = down.begin(); it != down.end(); ++it) {
+      for (std::vector<int>::const_iterator it2 = it->m_upward.begin(); it2 != it->m_upward.end(); ++it2) {
+        assert(downPos[*it2] < N);
+        allShared[*it2 * N + downPos[*it2]] = &it->m_sharedRanks;
+        downward[*it2 * N + downPos[*it2]] = it->m_gid;
+        downPos[*it2]++;
+      }
+    }
 
-		delete [] downPos;
+    delete[] downPos;
 
-		// Create the intersection of the shared ranks and update the elements
-		assert(N >= 2);
-		for (unsigned int i = 0; i < elements.size(); i++) {
-			assert(allShared[i*N]);
-			assert(allShared[i*N+1]);
+    // Create the intersection of the shared ranks and update the elements
+    assert(N >= 2);
+    for (unsigned int i = 0; i < elements.size(); i++) {
+      assert(allShared[i * N]);
+      assert(allShared[i * N + 1]);
 
-			std::set_intersection(allShared[i*N]->begin(), allShared[i*N]->end(),
-				allShared[i*N + 1]->begin(), allShared[i*N + 1]->end(),
-				std::back_inserter(elements[i].m_sharedRanks));
+      std::set_intersection(allShared[i * N]->begin(), allShared[i * N]->end(), allShared[i * N + 1]->begin(),
+                            allShared[i * N + 1]->end(), std::back_inserter(elements[i].m_sharedRanks));
 
-			std::vector<int> buffer;
-			for (unsigned int j = 2; j < N; j++) {
-				buffer.clear();
+      std::vector<int> buffer;
+      for (unsigned int j = 2; j < N; j++) {
+        buffer.clear();
 
-				assert(allShared[i*N+j]);
-				std::set_intersection(elements[i].m_sharedRanks.begin(), elements[i].m_sharedRanks.end(),
-					allShared[i*N + j]->begin(), allShared[i*N + j]->end(),
-					std::back_inserter(buffer));
+        assert(allShared[i * N + j]);
+        std::set_intersection(elements[i].m_sharedRanks.begin(), elements[i].m_sharedRanks.end(),
+                              allShared[i * N + j]->begin(), allShared[i * N + j]->end(), std::back_inserter(buffer));
 
-				std::swap(elements[i].m_sharedRanks, buffer);
-			}
-		}
+        std::swap(elements[i].m_sharedRanks, buffer);
+      }
+    }
 
-		delete [] allShared;
+    delete[] allShared;
 
-		// Eliminate false positves
-		int rank, procs;
-		MPI_Comm_rank(m_comm, &rank);
-		MPI_Comm_size(m_comm, &procs);
+    // Eliminate false positves
+    int rank, procs;
+    MPI_Comm_rank(m_comm, &rank);
+    MPI_Comm_size(m_comm, &procs);
 
-		int* nShared = new int[procs];
-		memset(nShared, 0, procs * sizeof(int));
-		for (typename std::vector<E>::const_iterator it = elements.begin();
-				it != elements.end(); ++it) {
-			for (std::vector<int>::const_iterator it2 = it->m_sharedRanks.begin();
-					it2 != it->m_sharedRanks.end(); ++it2) {
-				nShared[*it2]++;
-			}
-		}
+    int* nShared = new int[procs];
+    memset(nShared, 0, procs * sizeof(int));
+    for (typename std::vector<E>::const_iterator it = elements.begin(); it != elements.end(); ++it) {
+      for (std::vector<int>::const_iterator it2 = it->m_sharedRanks.begin(); it2 != it->m_sharedRanks.end(); ++it2) {
+        nShared[*it2]++;
+      }
+    }
 
-		int *nRecvShared = new int[procs];
-		MPI_Alltoall(nShared, 1, MPI_INT, nRecvShared, 1, MPI_INT, m_comm);
+    int* nRecvShared = new int[procs];
+    MPI_Alltoall(nShared, 1, MPI_INT, nRecvShared, 1, MPI_INT, m_comm);
 
-		int *sDispls = new int[procs];
-		int *rDispls = new int[procs];
-		sDispls[0] = 0;
-		rDispls[0] = 0;
-		for (int i = 1; i < procs; i++) {
-			sDispls[i] = sDispls[i-1] + nShared[i-1];
-			rDispls[i] = rDispls[i-1] + nRecvShared[i-1];
-		}
+    int* sDispls = new int[procs];
+    int* rDispls = new int[procs];
+    sDispls[0] = 0;
+    rDispls[0] = 0;
+    for (int i = 1; i < procs; i++) {
+      sDispls[i] = sDispls[i - 1] + nShared[i - 1];
+      rDispls[i] = rDispls[i - 1] + nRecvShared[i - 1];
+    }
 
-		unsigned int totalShared = sDispls[procs-1] + nShared[procs-1];
+    unsigned int totalShared = sDispls[procs - 1] + nShared[procs - 1];
 
-		unsigned int* sharedPos = new unsigned int[procs];
-		memset(sharedPos, 0, procs * sizeof(unsigned int));
+    unsigned int* sharedPos = new unsigned int[procs];
+    memset(sharedPos, 0, procs * sizeof(unsigned int));
 
-		unsigned long* sendShared = new unsigned long[totalShared * N];
+    unsigned long* sendShared = new unsigned long[totalShared * N];
 
-		for (unsigned int i = 0; i < elements.size(); i++) {
-			for (std::vector<int>::const_iterator it = elements[i].m_sharedRanks.begin();
-					it != elements[i].m_sharedRanks.end(); ++it) {
-				assert(sharedPos[*it] < static_cast<unsigned>(nShared[*it]));
-				memcpy(&sendShared[(sDispls[*it]+sharedPos[*it])*N], &downward[i * N],
-					N * sizeof(unsigned long));
-				sharedPos[*it]++;
-			}
-		}
+    for (unsigned int i = 0; i < elements.size(); i++) {
+      for (std::vector<int>::const_iterator it = elements[i].m_sharedRanks.begin();
+           it != elements[i].m_sharedRanks.end(); ++it) {
+        assert(sharedPos[*it] < static_cast<unsigned>(nShared[*it]));
+        memcpy(&sendShared[(sDispls[*it] + sharedPos[*it]) * N], &downward[i * N], N * sizeof(unsigned long));
+        sharedPos[*it]++;
+      }
+    }
 
-		delete [] sharedPos;
+    delete[] sharedPos;
 
-		unsigned int totalRecvShared = rDispls[procs-1] + nRecvShared[procs-1];
+    unsigned int totalRecvShared = rDispls[procs - 1] + nRecvShared[procs - 1];
 
-		unsigned long* recvShared = new unsigned long[totalRecvShared * N];
+    unsigned long* recvShared = new unsigned long[totalRecvShared * N];
 
-		MPI_Datatype type;
-		MPI_Type_contiguous(N, MPI_UNSIGNED_LONG, &type);
-		MPI_Type_commit(&type);
+    MPI_Datatype type;
+    MPI_Type_contiguous(N, MPI_UNSIGNED_LONG, &type);
+    MPI_Type_commit(&type);
 
-		MPI_Alltoallv(sendShared, nShared, sDispls, type,
-			recvShared, nRecvShared, rDispls, type,
-			m_comm);
+    MPI_Alltoallv(sendShared, nShared, sDispls, type, recvShared, nRecvShared, rDispls, type, m_comm);
 
-		delete [] nShared;
-		delete [] sendShared;
+    delete[] nShared;
+    delete[] sendShared;
 
-		std::unordered_set<internal::DownElement<N>, internal::DownElementHash<N> >* hashedElements
-			= new std::unordered_set<internal::DownElement<N>, internal::DownElementHash<N> >[procs];
+    std::unordered_set<internal::DownElement<N>, internal::DownElementHash<N>>* hashedElements =
+        new std::unordered_set<internal::DownElement<N>, internal::DownElementHash<N>>[procs];
 
-		unsigned int k = 0;
-		for (int i = 0; i < procs; i++) {
-			assert(i != rank || nRecvShared[i] == 0);
-			for (int j = 0; j < nRecvShared[i]; j++) {
-				assert(k < totalRecvShared);
-				assert(hashedElements[i].find(&recvShared[k*N]) == hashedElements[i].end());
-				hashedElements[i].emplace(&recvShared[k*N]);
-				k++;
-			}
-		}
+    unsigned int k = 0;
+    for (int i = 0; i < procs; i++) {
+      assert(i != rank || nRecvShared[i] == 0);
+      for (int j = 0; j < nRecvShared[i]; j++) {
+        assert(k < totalRecvShared);
+        assert(hashedElements[i].find(&recvShared[k * N]) == hashedElements[i].end());
+        hashedElements[i].emplace(&recvShared[k * N]);
+        k++;
+      }
+    }
 
-		delete [] nRecvShared;
-		delete [] recvShared;
+    delete[] nRecvShared;
+    delete[] recvShared;
 
-		unsigned int e = 0;
-		for (unsigned int i = 0; i < elements.size(); i++) {
-			internal::DownElement<N> delem(&downward[i * N]);
+    unsigned int e = 0;
+    for (unsigned int i = 0; i < elements.size(); i++) {
+      internal::DownElement<N> delem(&downward[i * N]);
 
-			std::vector<int>::iterator it = elements[i].m_sharedRanks.begin();
-			while (it != elements[i].m_sharedRanks.end()) {
-				if (hashedElements[*it].find(delem) == hashedElements[*it].end()) {
-					if ((rank == 0 && *it == 3) || (rank == 3 && *it == 0))
-						e++;
-					it = elements[i].m_sharedRanks.erase(it);
-				} else {
-					++it;
-				}
-			}
-		}
+      std::vector<int>::iterator it = elements[i].m_sharedRanks.begin();
+      while (it != elements[i].m_sharedRanks.end()) {
+        if (hashedElements[*it].find(delem) == hashedElements[*it].end()) {
+          if ((rank == 0 && *it == 3) || (rank == 3 && *it == 0))
+            e++;
+          it = elements[i].m_sharedRanks.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
 
-		delete [] hashedElements;
+    delete[] hashedElements;
 
-		// Count owned elements
-		unsigned int owned = 0;
-		for (typename std::vector<E>::const_iterator it = elements.begin();
-				it != elements.end(); ++it) {
-			if (it->m_sharedRanks.empty() || it->m_sharedRanks[0] > rank)
-				owned++;
-		}
+    // Count owned elements
+    unsigned int owned = 0;
+    for (typename std::vector<E>::const_iterator it = elements.begin(); it != elements.end(); ++it) {
+      if (it->m_sharedRanks.empty() || it->m_sharedRanks[0] > rank)
+        owned++;
+    }
 
-		// Get global id offset
-		unsigned long gidOffset = owned;
-		MPI_Scan(MPI_IN_PLACE, &gidOffset, 1, MPI_UNSIGNED_LONG, MPI_SUM, m_comm);
-		gidOffset -= owned;
+    // Get global id offset
+    unsigned long gidOffset = owned;
+    MPI_Scan(MPI_IN_PLACE, &gidOffset, 1, MPI_UNSIGNED_LONG, MPI_SUM, m_comm);
+    gidOffset -= owned;
 
-		// Set global ids for owned elements and count the number of elements we need to forward
-		int* nSendGid = new int[procs];
-		memset(nSendGid, 0, procs * sizeof(int));
-		int* nRecvGid = new int[procs];
-		memset(nRecvGid, 0, procs * sizeof(int));
-		for (typename std::vector<E>::iterator it = elements.begin();
-				it != elements.end(); ++it) {
-			if (it->m_sharedRanks.empty() || it->m_sharedRanks[0] > rank) {
-				it->m_gid = gidOffset++;
+    // Set global ids for owned elements and count the number of elements we need to forward
+    int* nSendGid = new int[procs];
+    memset(nSendGid, 0, procs * sizeof(int));
+    int* nRecvGid = new int[procs];
+    memset(nRecvGid, 0, procs * sizeof(int));
+    for (typename std::vector<E>::iterator it = elements.begin(); it != elements.end(); ++it) {
+      if (it->m_sharedRanks.empty() || it->m_sharedRanks[0] > rank) {
+        it->m_gid = gidOffset++;
 
-				for (std::vector<int>::const_iterator it2 = it->m_sharedRanks.begin();
-						it2 != it->m_sharedRanks.end(); ++it2) {
-					nSendGid[*it2]++;
-				}
-			} else {
-				it->m_gid = std::numeric_limits<unsigned long>::max();
+        for (std::vector<int>::const_iterator it2 = it->m_sharedRanks.begin(); it2 != it->m_sharedRanks.end(); ++it2) {
+          nSendGid[*it2]++;
+        }
+      } else {
+        it->m_gid = std::numeric_limits<unsigned long>::max();
 
-				if (!it->m_sharedRanks.empty())
-					nRecvGid[it->m_sharedRanks[0]]++;
-			}
-		}
+        if (!it->m_sharedRanks.empty())
+          nRecvGid[it->m_sharedRanks[0]]++;
+      }
+    }
 
-		// Compute exchange offsets
-		sDispls[0] = 0;
-		rDispls[0] = 0;
-		for (int i = 1; i < procs; i++) {
-			sDispls[i] = sDispls[i-1] + nSendGid[i-1];
-			rDispls[i] = rDispls[i-1] + nRecvGid[i-1];
-		}
+    // Compute exchange offsets
+    sDispls[0] = 0;
+    rDispls[0] = 0;
+    for (int i = 1; i < procs; i++) {
+      sDispls[i] = sDispls[i - 1] + nSendGid[i - 1];
+      rDispls[i] = rDispls[i - 1] + nRecvGid[i - 1];
+    }
 
-		unsigned int totalSendGid = sDispls[procs-1] + nSendGid[procs-1];
-		unsigned int totalRecvGid = rDispls[procs-1] + nRecvGid[procs-1];
+    unsigned int totalSendGid = sDispls[procs - 1] + nSendGid[procs - 1];
+    unsigned int totalRecvGid = rDispls[procs - 1] + nRecvGid[procs - 1];
 
-		// Collect send data
-		unsigned int* sendPos = new unsigned int[procs];
-		memset(sendPos, 0, procs * sizeof(unsigned int));
+    // Collect send data
+    unsigned int* sendPos = new unsigned int[procs];
+    memset(sendPos, 0, procs * sizeof(unsigned int));
 
-		unsigned long* sendGid = new unsigned long[totalSendGid];
-		unsigned long* sendDGid = new unsigned long[totalSendGid * N];
-		for (unsigned int i = 0; i < elements.size(); i++) {
-			if (elements[i].m_sharedRanks.empty() || elements[i].m_sharedRanks[0] > rank) {
-				for (std::vector<int>::const_iterator it = elements[i].m_sharedRanks.begin();
-						it != elements[i].m_sharedRanks.end(); ++it) {
-					assert(sendPos[*it] < static_cast<unsigned>(nSendGid[*it]));
+    unsigned long* sendGid = new unsigned long[totalSendGid];
+    unsigned long* sendDGid = new unsigned long[totalSendGid * N];
+    for (unsigned int i = 0; i < elements.size(); i++) {
+      if (elements[i].m_sharedRanks.empty() || elements[i].m_sharedRanks[0] > rank) {
+        for (std::vector<int>::const_iterator it = elements[i].m_sharedRanks.begin();
+             it != elements[i].m_sharedRanks.end(); ++it) {
+          assert(sendPos[*it] < static_cast<unsigned>(nSendGid[*it]));
 
-					sendGid[sDispls[*it] + sendPos[*it]] = elements[i].m_gid;
-					memcpy(&sendDGid[(sDispls[*it] + sendPos[*it])*N], &downward[i*N], N*sizeof(unsigned long));
-					sendPos[*it]++;
-				}
-			}
-		}
+          sendGid[sDispls[*it] + sendPos[*it]] = elements[i].m_gid;
+          memcpy(&sendDGid[(sDispls[*it] + sendPos[*it]) * N], &downward[i * N], N * sizeof(unsigned long));
+          sendPos[*it]++;
+        }
+      }
+    }
 
-		delete [] sendPos;
+    delete[] sendPos;
 
-		// Exchange cell data
-		unsigned long* recvGid = new unsigned long[totalRecvGid];
-		unsigned long* recvDGid = new unsigned long[totalRecvGid*N];
+    // Exchange cell data
+    unsigned long* recvGid = new unsigned long[totalRecvGid];
+    unsigned long* recvDGid = new unsigned long[totalRecvGid * N];
 
-		MPI_Alltoallv(sendGid, nSendGid, sDispls, MPI_UNSIGNED_LONG,
-			recvGid, nRecvGid, rDispls, MPI_UNSIGNED_LONG,
-			m_comm);
+    MPI_Alltoallv(sendGid, nSendGid, sDispls, MPI_UNSIGNED_LONG, recvGid, nRecvGid, rDispls, MPI_UNSIGNED_LONG, m_comm);
 
-		MPI_Alltoallv(sendDGid, nSendGid, sDispls, type,
-			recvDGid, nRecvGid, rDispls, type,
-			m_comm);
+    MPI_Alltoallv(sendDGid, nSendGid, sDispls, type, recvDGid, nRecvGid, rDispls, type, m_comm);
 
-		MPI_Type_free(&type);
+    MPI_Type_free(&type);
 
-		delete [] sendGid;
-		delete [] sendDGid;
-		delete [] nSendGid;
-		delete [] nRecvGid;
-		delete [] sDispls;
-		delete [] rDispls;
+    delete[] sendGid;
+    delete[] sendDGid;
+    delete[] nSendGid;
+    delete[] nRecvGid;
+    delete[] sDispls;
+    delete[] rDispls;
 
-		// Create a hash map from the received elements
-		std::unordered_map<internal::DownElement<N>, unsigned long, internal::DownElementHash<N> > dg2g;
-		for (unsigned int i = 0; i < totalRecvGid; i++) {
-			dg2g.emplace(&recvDGid[i*N], recvGid[i]);
-		}
+    // Create a hash map from the received elements
+    std::unordered_map<internal::DownElement<N>, unsigned long, internal::DownElementHash<N>> dg2g;
+    for (unsigned int i = 0; i < totalRecvGid; i++) {
+      dg2g.emplace(&recvDGid[i * N], recvGid[i]);
+    }
 
-		delete [] recvGid;
-		delete [] recvDGid;
+    delete[] recvGid;
+    delete[] recvDGid;
 
-		// Assign gids
-		for (unsigned int i = 0; i < elements.size(); i++) {
-			if (!elements[i].m_sharedRanks.empty() && elements[i].m_sharedRanks[0] < rank) {
-				assert(elements[i].m_gid == std::numeric_limits<unsigned long>::max());
+    // Assign gids
+    for (unsigned int i = 0; i < elements.size(); i++) {
+      if (!elements[i].m_sharedRanks.empty() && elements[i].m_sharedRanks[0] < rank) {
+        assert(elements[i].m_gid == std::numeric_limits<unsigned long>::max());
 
-				internal::DownElement<N> delem(&downward[i * N]);
-				typename std::unordered_map<internal::DownElement<N>, unsigned long, internal::DownElementHash<N> >::const_iterator it
-					= dg2g.find(delem);
-				assert(it != dg2g.end());
+        internal::DownElement<N> delem(&downward[i * N]);
+        typename std::unordered_map<internal::DownElement<N>, unsigned long,
+                                    internal::DownElementHash<N>>::const_iterator it = dg2g.find(delem);
+        assert(it != dg2g.end());
 
-				elements[i].m_gid = it->second;
-			}
-		}
+        elements[i].m_gid = it->second;
+      }
+    }
 
-		delete [] downward;
+    delete[] downward;
 #endif // USE_MPI
-	}
+  }
 
-private:
-	/**
-	 * Add an edge if it does not exist yet
-	 *
-	 * @param edgeUpward The storage for upward information
-	 * @param lid The local id of the edge
-	 * @param plid1 The first parent
-	 * @param plid2 The second parent
-	 * @return The local id of the edge
-	 */
-	static unsigned int addEdge(std::vector<std::set<unsigned int> > &edgeUpward,
-		unsigned int lid, unsigned int plid1, unsigned int plid2)
-	{
-		if (lid >= edgeUpward.size()) {
-			assert(lid == edgeUpward.size());
-			edgeUpward.push_back(std::set<unsigned int>());
-		}
-		edgeUpward[lid].insert(plid1);
-		edgeUpward[lid].insert(plid2);
+  private:
+  /**
+   * Add an edge if it does not exist yet
+   *
+   * @param edgeUpward The storage for upward information
+   * @param lid The local id of the edge
+   * @param plid1 The first parent
+   * @param plid2 The second parent
+   * @return The local id of the edge
+   */
+  static unsigned int addEdge(std::vector<std::set<unsigned int>>& edgeUpward, unsigned int lid, unsigned int plid1,
+                              unsigned int plid2) {
+    if (lid >= edgeUpward.size()) {
+      assert(lid == edgeUpward.size());
+      edgeUpward.push_back(std::set<unsigned int>());
+    }
+    edgeUpward[lid].insert(plid1);
+    edgeUpward[lid].insert(plid2);
 
-		return lid;
-	}
+    return lid;
+  }
 
-	/**
-	 * Constructs the global -> local map for an element array
-	 */
-	template<typename TT>
-	static void constructG2L(const std::vector<TT> &elements, g2l_t &g2lMap)
-	{
-		g2lMap.clear();
+  /**
+   * Constructs the global -> local map for an element array
+   */
+  template <typename TT> static void constructG2L(const std::vector<TT>& elements, g2l_t& g2lMap) {
+    g2lMap.clear();
 
-		unsigned int i = 0;
-		for (typename std::vector<TT>::const_iterator it = elements.begin();
-				it != elements.end(); ++it, i++) {
-			assert(g2lMap.find(it->m_gid) == g2lMap.end());
-			g2lMap[it->m_gid] = i;
-		}
-	}
+    unsigned int i = 0;
+    for (typename std::vector<TT>::const_iterator it = elements.begin(); it != elements.end(); ++it, i++) {
+      assert(g2lMap.find(it->m_gid) == g2lMap.end());
+      g2lMap[it->m_gid] = i;
+    }
+  }
 
-	template<typename TT>
-	static void _checkH5Err(TT status, const char* file, int line)
-	{
-		if (status < 0)
-			logError() << utils::nospace << "An HDF5 error occurred in PUML ("
-				<< file << ": " << line << ")";
-	}
+  template <typename TT> static void _checkH5Err(TT status, const char* file, int line) {
+    if (status < 0)
+      logError() << utils::nospace << "An HDF5 error occurred in PUML (" << file << ": " << line << ")";
+  }
 };
 
 #undef checkH5Err
@@ -1279,6 +1184,6 @@ private:
 /** Convenient typedef for tetrahrdral meshes */
 typedef PUML<TETRAHEDRON> TETPUML;
 
-}
+} // namespace PUML
 
 #endif // PUML_PUML_H

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -50,7 +50,7 @@ class PartitionMetis {
   idx_t* xadj = nullptr;
   size_t xadj_size = 0;
   idx_t* adjncy = nullptr;
-  soze_t adjncy_size = 0;
+  size_t adjncy_size = 0;
 
  public:
   PartitionMetis(const cell_t* cells, unsigned int numCells)
@@ -118,7 +118,7 @@ class PartitionMetis {
       //  - vtxdist[proc] + vtxdist[proc+1]
       //  because proc has the index proc to proc +1 elements
 
-      xadj_size = vtxdist[procs + 1] - vtxdist[proc];
+      xadj_size = vtxdist[procs + 1] - vtxdist[procs];
 
       // last element of xadj will be the size of adjncy
       adjncy_size = xadj[xadj_size - 1];

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -120,7 +120,7 @@ template <TopoType Topo> class PartitionMetis {
 
       assert(vtxdist.size() == static_cast<size_t>(procs + 1));
       // the first element is always 0 and on top of that we have n nodes
-      size_t numElements = vtxdist[rank + 1] - vtxdist[rank];
+      size_t numElements = vtxdist[rank + 1] - vtxdist[rank] + 1;
       xadj.reserve(numElements);
       std::copy(metis_xadj, metis_xadj + numElements, std::back_inserter(xadj));
 

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -108,7 +108,7 @@ class PartitionMetis {
       ParMETIS_V3_Mesh2Dual(elemdist, eptr, eind, &numflag, &ncommonnodes,
                             &xadj, &adjncy, &m_comm);
 
-      vtxdist = elmdist;
+      vtxdist = elemdist;
       delete[] eptr;
       delete[] eind;
     }
@@ -118,7 +118,7 @@ class PartitionMetis {
 #ifdef USE_MPI
   std::tuple<const idx_t*, const idx_t*, const idx_t*> getGraph() {
     if (xadj == nullptr && adjncy == nullptr) {
-      generateGraph();
+      generateGraphFromMesh();
     }
 
     return {vtxdist, xadj, adjncy};
@@ -182,7 +182,7 @@ class PartitionMetis {
     idx_t edgecut;
     idx_t options[3] = {1, 1, METIS_RANDOM_SEED};
 
-    idx t* part = new idx_t[m_numCells];
+    idx_t* part = new idx_t[m_numCells];
 
     auto metisResult = ParMETIS_V3_PartKway(
       vtxdist, xadj, adjncy, elmwgt, &wgtflag, nullptr, &numflag, &ncon,

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -223,6 +223,9 @@ template <TopoType Topo> class PartitionMetis {
 
     idx_t* part = new idx_t[m_numCells];
 
+    assert(xadj.size() == static_cast<size_t>(vtxdist[rank + 1] - vtxdist[rank] + 1));
+    assert(adjncy.size() == static_cast<size_t>(xadj.back()));
+
     auto metisResult = ParMETIS_V3_PartKway(vtxdist.data(), xadj.data(), adjncy.data(), elmwgt, edgewgt, &wgtflag,
                                             &numflag, &ncon, &nparts, tpwgts, ubvec, options, &edgecut, part, &m_comm);
     /*

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -113,7 +113,7 @@ template <TopoType Topo> class PartitionMetis {
                             &metis_adjncy, &m_comm);
 
       vtxdist.reserve(procs + 1);
-      assert(elemdist.size() == procs.size());
+      assert(elemdist.size() == procs + 1);
       std::copy(elemdist.begin(), elemdist.end(), std::back_inserter(vtxdist));
       assert(vtxdist.size() == procs + 1);
 
@@ -192,8 +192,8 @@ template <TopoType Topo> class PartitionMetis {
     if (edgeWeights != nullptr) {
       assert(edgeCount != 0);
       edgewgt = new idx_t[edgeCount];
-      for (idx_t i = 0; i < edgeCount; ++i) {
-        elmwgt[i] = static_cast<idx_t>(edgeWeights[i]);
+      for (size_t i = 0; i < edgeCount; ++i) {
+        edgewgt[i] = static_cast<idx_t>(edgeWeights[i]);
       }
     }
 

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -112,17 +112,15 @@ template <TopoType Topo> class PartitionMetis {
       ParMETIS_V3_Mesh2Dual(elemdist.data(), eptr.data(), eind.data(), &numflag, &ncommonnodes, &metis_xadj,
                             &metis_adjncy, &m_comm);
 
-      vtxdist.reserve(procs + 1);
-      assert(elemdist.size() == procs + 1);
-      std::copy(elemdist.begin(), elemdist.end(), std::back_inserter(vtxdist));
-      assert(vtxdist.size() == procs + 1);
+      vtxdist = std::move(elemdist);
 
       //  the size of xadj is the
       //  - vtxdist[proc] + vtxdist[proc+1]
       //  because proc has the index proc to proc +1 elements
 
-      assert(rank + 1 < procs);
-      size_t numElements = vtxdist[rank + 1] - vtxdist[rank];
+      assert(vtxdist.size() == procs + 1);
+      // the first element is always 0 and on top of that we have n nodes
+      size_t numElements = vtxdist[rank + 1] - vtxdist[rank] + 1;
       xadj.reserve(numElements);
       std::copy(metis_xadj, metis_xadj + numElements, std::back_inserter(xadj));
 

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -185,7 +185,7 @@ class PartitionMetis {
     idx_t* part = new idx_t[m_numCells];
 
     auto metisResult = ParMETIS_V3_PartKway(
-      vtxdist, xadj, adjncy, elmwgt, &wgtflag, nullptr, &numflag, &ncon,
+      vtxdist, xadj, adjncy, elmwgt, nullptr, &wgtflag, &numflag, &ncon,
       &nparts, tpwgts, ubvec, options, &edgecut, part, &m_comm);
     /*
     ParMETIS_V3_PartMeshKway(

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -70,7 +70,7 @@ template <TopoType Topo> class PartitionMetis {
   void generateGraphFromMesh() {
     assert(xadj.empty() && adjncy.empty() || !xadj.empty() && !adjncy.empty());
 
-    if (xxadj.empty() && adjncy.empty()) {
+    if (xadj.empty() && adjncy.empty()) {
       std::vector<idx_t> elemdist;
       elemdist.resize(procs + 1);
       std::fill(elemdist.begin(), elemdist.end(), 0);
@@ -109,11 +109,12 @@ template <TopoType Topo> class PartitionMetis {
       idx_t* metis_xadj;
       idx_t* metis_adjncy;
 
-      ParMETIS_V3_Mesh2Dual(elemdist, eptr, eind, &numflag, &ncommonnodes, &metis_xadj, &metis_adjncy, &m_comm);
+      ParMETIS_V3_Mesh2Dual(elemdist.data(), eptr.data(), eind.data(), &numflag, &ncommonnodes, &metis_xadj,
+                            &metis_adjncy, &m_comm);
 
       vtxdist.reserve(procs + 1);
       assert(elemdist.size() == procs.size());
-      std::copy(elemdist.begin(), elemdist.end(), std::back_inserter(vtxdist)));
+      std::copy(elemdist.begin(), elemdist.end(), std::back_inserter(vtxdist));
       assert(vtxdist.size() == procs + 1);
 
       //  the size of xadj is the
@@ -130,10 +131,8 @@ template <TopoType Topo> class PartitionMetis {
       adjncy.reserve(adjncySize);
       std::copy(metis_adjncy, metis_adjncy + adjncySize, std::back_inserter(adjncy));
 
-      delete[] eptr;
-      delete[] eind;
-      delete[] metis_xadj;
-      delete[] metis_adjncy;
+      METIS_Free(metis_xadj);
+      METIS_Free(metis_adjncy);
     }
   }
 #endif

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -189,7 +189,8 @@ class PartitionMetis {
 
     idx_t* edgewgt = nullptr;
     if (edgeWeights != nullptr) {
-      elmwgt = new idx_t[edgeCount];
+      assert(edgeCount != 0);
+      edgewgt = new idx_t[edgeCount];
       for (idx_t i = 0; i < edgeCount; ++i) {
         elmwgt[i] = static_cast<idx_t>(edgeWeights[i]);
       }

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -228,12 +228,7 @@ template <TopoType Topo> class PartitionMetis {
 
     auto metisResult = ParMETIS_V3_PartKway(vtxdist.data(), xadj.data(), adjncy.data(), elmwgt, edgewgt, &wgtflag,
                                             &numflag, &ncon, &nparts, tpwgts, ubvec, options, &edgecut, part, &m_comm);
-    /*
-    ParMETIS_V3_PartMeshKway(
-      elemdist, eptr, eind, elmwgt, &wgtflag, &numflag, &ncon, &ncommonnodes,
-      &nparts, tpwgts, ubvec, options, &edgecut, part, &m_comm);
-    */
-
+                                            
     delete[] tpwgts;
     delete[] ubvec;
     delete[] elmwgt;

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -68,9 +68,9 @@ template <TopoType Topo> class PartitionMetis {
 
 #ifdef USE_MPI
   void generateGraphFromMesh() {
-    assert(xadj.empty() && adjncy.empty() || !xadj.empty() && !adjncy.empty());
+    assert((vtxdist.empty() && xadj.empty() && adjncy.empty()) || (!vtxdist.empty() && !xadj.empty() && !adjncy.empty()));
 
-    if (xadj.empty() && adjncy.empty()) {
+    if (vtxdist.empty() && xadj.empty() && adjncy.empty()) {
       std::vector<idx_t> elemdist;
       elemdist.resize(procs + 1);
       std::fill(elemdist.begin(), elemdist.end(), 0);
@@ -118,9 +118,9 @@ template <TopoType Topo> class PartitionMetis {
       //  - vtxdist[proc] + vtxdist[proc+1]
       //  because proc has the index proc to proc +1 elements
 
-      assert(vtxdist.size() == procs + 1);
+      assert(vtxdist.size() == static_cast<size_t>(procs + 1));
       // the first element is always 0 and on top of that we have n nodes
-      size_t numElements = vtxdist[rank + 1] - vtxdist[rank] + 1;
+      size_t numElements = vtxdist[rank + 1] - vtxdist[rank];
       xadj.reserve(numElements);
       std::copy(metis_xadj, metis_xadj + numElements, std::back_inserter(xadj));
 
@@ -128,6 +128,8 @@ template <TopoType Topo> class PartitionMetis {
       size_t adjncySize = xadj[numElements - 1];
       adjncy.reserve(adjncySize);
       std::copy(metis_adjncy, metis_adjncy + adjncySize, std::back_inserter(adjncy));
+
+
 
       METIS_Free(metis_xadj);
       METIS_Free(metis_adjncy);

--- a/PartitionMetis.h
+++ b/PartitionMetis.h
@@ -56,16 +56,24 @@ public:
 #endif // USE_MPI
 
 #ifdef USE_MPI
+	enum Status {
+		Ok,
+		Error
+	};
+
 	/**
 	 * @param partition An array of size <code>numCells</code> which
 	 *  will contain the partition for each cells
-         * @param vertexWeights Weight for each vertex
-         * @param nWeightsPerVertex Number of weights per vertex
-         * @param nodeWeights Weight for each node
-	 * @param imbalance The allowed imbalance
+	 * @param vertexWeights Weight for each vertex
+	 * @param nWeightsPerVertex Number of weights per vertex
+	 * @param nodeWeights Weight for each node
+	 * @param imbalance The allowed imbalance for each constrain
 	 */
-	void partition(int* partition, int const* vertexWeights = nullptr, int nWeightsPerVertex = 1, double* nodeWeights = nullptr, double imbalance = 1.05)
-	{
+	Status partition(int* partition,
+		const int* vertexWeights = nullptr,
+		const double* imbalances = nullptr,
+		int nWeightsPerVertex = 1,
+		const double* nodeWeights = nullptr) {
 		int rank, procs;
 		MPI_Comm_rank(m_comm, &rank);
 		MPI_Comm_size(m_comm, &procs);
@@ -93,45 +101,60 @@ public:
 		}
 		eptr[m_numCells] = m_numCells * internal::Topology<Topo>::cellvertices();
     
-    idx_t wgtflag = 0;
-    idx_t* elmwgt = nullptr;
-    if (vertexWeights != nullptr) {
-      wgtflag = 2;
-      elmwgt = new idx_t[m_numCells];
-      for (idx_t i = 0; i < m_numCells; i++) {
-        elmwgt[i] = static_cast<idx_t>(vertexWeights[i]);
-      }
-    }
+		idx_t wgtflag = 0;
+		idx_t ncon = nWeightsPerVertex;
+		idx_t* elmwgt = nullptr;
+		if (vertexWeights != nullptr) {
+			wgtflag = 2;
+			elmwgt = new idx_t[m_numCells * ncon];
+			for (idx_t cell = 0; cell < m_numCells; ++cell) {
+				for (idx_t j = 0; j < ncon; ++j) {
+					elmwgt[ncon * cell  + j] = static_cast<idx_t>(vertexWeights[ncon * cell + j]);
+				}
+			}
+		}
 
 		idx_t numflag = 0;
-		idx_t ncon = nWeightsPerVertex;
 		idx_t ncommonnodes = 3; // TODO adapt for hex
 		idx_t nparts = procs;
 
 		real_t* tpwgts = new real_t[nparts * ncon];
-    if (nodeWeights != nullptr) {
-      for (idx_t i = 0; i < nparts; i++) {
-        for (idx_t j = 0; j < ncon; ++j) {
-          tpwgts[i*ncon + j] = nodeWeights[i];
-        }
-      }
-    } else {
-      for (idx_t i = 0; i < nparts * ncon; i++) {
-        tpwgts[i] = static_cast<real_t>(1.) / nparts;
-      }
-    }
+		if (nodeWeights != nullptr) {
+			for (idx_t i = 0; i < nparts; i++) {
+				for (idx_t j = 0; j < ncon; ++j) {
+					tpwgts[i*ncon + j] = nodeWeights[i];
+				}
+			}
+		} else {
+			for (idx_t i = 0; i < nparts * ncon; i++) {
+				tpwgts[i] = static_cast<real_t>(1.) / nparts;
+			}
+		}
 
 		real_t* ubvec = new real_t[ncon];
 		for (idx_t i = 0; i < ncon; ++i) {
-			ubvec[i] = imbalance;
+			ubvec[i] = imbalances[i];
 		}
 		idx_t edgecut;
-		idx_t options[3] = {1, 0, METIS_RANDOM_SEED};
+		idx_t options[3] = {1, 1, METIS_RANDOM_SEED};
 
 		idx_t* part = new idx_t[m_numCells];
 
-		ParMETIS_V3_PartMeshKway(elemdist, eptr, eind, elmwgt, &wgtflag, &numflag,
-			&ncon, &ncommonnodes, &nparts, tpwgts, ubvec, options, &edgecut, part, &m_comm);
+		auto metisResult = ParMETIS_V3_PartMeshKway(elemdist,
+                                                eptr,
+                                                eind,
+                                                elmwgt,
+                                                &wgtflag,
+                                                &numflag,
+                                                &ncon,
+                                                &ncommonnodes,
+                                                &nparts,
+                                                tpwgts,
+                                                ubvec,
+                                                options,
+                                                &edgecut,
+                                                part,
+                                                &m_comm);
 
 		delete [] elemdist;
 		delete [] eptr;
@@ -143,6 +166,8 @@ public:
 			partition[i] = part[i];
 
 		delete [] part;
+
+		return (metisResult == METIS_OK) ? Status::Ok : Status::Error;
 	}
 #endif // USE_MPI
 

--- a/Topology.h
+++ b/Topology.h
@@ -13,88 +13,64 @@
 #ifndef PUML_TOPOLOGY_H
 #define PUML_TOPOLOGY_H
 
-namespace PUML
-{
+namespace PUML {
 
 /**
  * The topology types
  */
-enum TopoType {
-	TETRAHEDRON,
-	HEXAHEDRON
-};
+enum TopoType { TETRAHEDRON, HEXAHEDRON };
 
-namespace internal
-{
+namespace internal {
 
 /**
  * Class describing the different topologies
  */
-template<TopoType>
-class Topology
-{
-public:
-	/**
-	 * @return The number of vertices of a cell
-	 */
-	static constexpr unsigned int cellvertices();
+template <TopoType> class Topology {
+  public:
+  /**
+   * @return The number of vertices of a cell
+   */
+  static constexpr unsigned int cellvertices();
 
-	/**
-	 * @return The number of faces of a cell
-	 */
-	static constexpr unsigned int cellfaces();
+  /**
+   * @return The number of faces of a cell
+   */
+  static constexpr unsigned int cellfaces();
 
-	/**
-	 * @return The number of edges for a cell
-	 */
-	static constexpr unsigned int celledges();
+  /**
+   * @return The number of edges for a cell
+   */
+  static constexpr unsigned int celledges();
 
-	/**
-	 * @return The number of edges for a face
-	 */
-	static constexpr unsigned int faceedges()
-	{ return facevertices(); /* This is always the same */ }
+  /**
+   * @return The number of edges for a face
+   */
+  static constexpr unsigned int faceedges() { return facevertices(); /* This is always the same */ }
 
-	/**
-	 * @return The number vertices for a face
-	 */
-	static constexpr unsigned int facevertices();
+  /**
+   * @return The number vertices for a face
+   */
+  static constexpr unsigned int facevertices();
 };
 
-template<> inline
-constexpr unsigned int Topology<TETRAHEDRON>::cellvertices()
-{ return 4; }
+template <> inline constexpr unsigned int Topology<TETRAHEDRON>::cellvertices() { return 4; }
 
-template<> inline
-constexpr unsigned int Topology<HEXAHEDRON>::cellvertices()
-{ return 8; }
+template <> inline constexpr unsigned int Topology<HEXAHEDRON>::cellvertices() { return 8; }
 
-template<> inline
-constexpr unsigned int Topology<TETRAHEDRON>::cellfaces()
-{ return 4; }
+template <> inline constexpr unsigned int Topology<TETRAHEDRON>::cellfaces() { return 4; }
 
-template<> inline
-constexpr unsigned int Topology<HEXAHEDRON>::cellfaces()
-{ return 6; }
+template <> inline constexpr unsigned int Topology<HEXAHEDRON>::cellfaces() { return 6; }
 
-template<> inline
-constexpr unsigned int Topology<TETRAHEDRON>::celledges()
-{ return 6; }
+template <> inline constexpr unsigned int Topology<TETRAHEDRON>::celledges() { return 6; }
 
-template<> inline
-constexpr unsigned int Topology<HEXAHEDRON>::celledges()
-{ return 12; }
+template <> inline constexpr unsigned int Topology<HEXAHEDRON>::celledges() { return 12; }
 
-template<> inline
-constexpr unsigned int Topology<TETRAHEDRON>::facevertices()
-{ return 3; }
+template <> inline constexpr unsigned int Topology<TETRAHEDRON>::facevertices() { return 3; }
 
-template<> inline
-constexpr unsigned int Topology<HEXAHEDRON>::facevertices()
-{ return 4; }
+template <> inline constexpr unsigned int Topology<HEXAHEDRON>::facevertices() { return 4; }
 
-}
+} // namespace internal
 
-}
+} // namespace PUML
 
 #endif // PUML_TOPOLOGY_H

--- a/Upward.h
+++ b/Upward.h
@@ -20,102 +20,82 @@
 #include "PUML.h"
 #include "Topology.h"
 
-namespace PUML
-{
+namespace PUML {
 
-class Upward
-{
-public:
-	/**
-	 * Returns all local cell ids for a face
-	 *
-	 * @param puml The PUML mesh
-	 * @param cell The face for which the cells should be returned
-	 * @param lid The local ids of the cells
-	 */
-	template<TopoType Topo>
-	static void cells(const PUML<Topo> &puml, const typename PUML<Topo>::face_t &face, int* lid)
-	{
-		memcpy(lid, face.m_upward, 2 * sizeof(int));
-	}
+class Upward {
+  public:
+  /**
+   * Returns all local cell ids for a face
+   *
+   * @param puml The PUML mesh
+   * @param cell The face for which the cells should be returned
+   * @param lid The local ids of the cells
+   */
+  template <TopoType Topo>
+  static void cells(const PUML<Topo>& puml, const typename PUML<Topo>::face_t& face, int* lid) {
+    memcpy(lid, face.m_upward, 2 * sizeof(int));
+  }
 
-	template<TopoType Topo, bool M = false>
-	static void faces(const PUML<Topo> &puml, const typename PUML<Topo>::edge_t &edge, std::vector<int> &lid)
-	{
-		merge<M>(lid, edge.m_upward);
-	}
+  template <TopoType Topo, bool M = false>
+  static void faces(const PUML<Topo>& puml, const typename PUML<Topo>::edge_t& edge, std::vector<int>& lid) {
+    merge<M>(lid, edge.m_upward);
+  }
 
-	template<TopoType Topo, bool M = false>
-	static void cells(const PUML<Topo> &puml, const typename PUML<Topo>::edge_t &edge, std::vector<int> &lid)
-	{
-		std::vector<int> faceIds;
-		faces(puml, edge, faceIds);
+  template <TopoType Topo, bool M = false>
+  static void cells(const PUML<Topo>& puml, const typename PUML<Topo>::edge_t& edge, std::vector<int>& lid) {
+    std::vector<int> faceIds;
+    faces(puml, edge, faceIds);
 
-		std::vector<int> cellIds;
-		for (std::vector<int>::const_iterator it = faceIds.begin();
-				it != faceIds.end(); ++it) {
-			int tmp[2];
-			cells(puml, puml.faces()[*it], tmp);
-			unsigned int c = (tmp[1] < 0 ? 1 : 2);
+    std::vector<int> cellIds;
+    for (std::vector<int>::const_iterator it = faceIds.begin(); it != faceIds.end(); ++it) {
+      int tmp[2];
+      cells(puml, puml.faces()[*it], tmp);
+      unsigned int c = (tmp[1] < 0 ? 1 : 2);
 
-			std::vector<int> merged;
-			std::set_union(cellIds.begin(), cellIds.end(),
-				tmp, tmp+c,
-				std::back_inserter(merged));
-			std::swap(merged, cellIds);
-		}
+      std::vector<int> merged;
+      std::set_union(cellIds.begin(), cellIds.end(), tmp, tmp + c, std::back_inserter(merged));
+      std::swap(merged, cellIds);
+    }
 
-		if (M)
-			merge<true>(lid, cellIds);
-		else
-			std::swap(lid, cellIds);
-	}
+    if (M)
+      merge<true>(lid, cellIds);
+    else
+      std::swap(lid, cellIds);
+  }
 
-	template<TopoType Topo, bool M = false>
-	static void edges(const PUML<Topo> &puml, const typename PUML<Topo>::vertex_t &vertex, std::vector<int> &lid)
-	{
-		merge<M>(lid, vertex.m_upward);
-	}
+  template <TopoType Topo, bool M = false>
+  static void edges(const PUML<Topo>& puml, const typename PUML<Topo>::vertex_t& vertex, std::vector<int>& lid) {
+    merge<M>(lid, vertex.m_upward);
+  }
 
-	template<TopoType Topo, bool M = false>
-	static void cells(const PUML<Topo> &puml, const typename PUML<Topo>::vertex_t &vertex, std::vector<int> &lid)
-	{
-		std::vector<int> edgeIds;
-		edges(puml, vertex, edgeIds);
+  template <TopoType Topo, bool M = false>
+  static void cells(const PUML<Topo>& puml, const typename PUML<Topo>::vertex_t& vertex, std::vector<int>& lid) {
+    std::vector<int> edgeIds;
+    edges(puml, vertex, edgeIds);
 
-		std::vector<int> cellIds;
-		for (std::vector<int>::const_iterator it = edgeIds.begin();
-				it != edgeIds.end(); ++it) {
-			merge<true>(cellIds, puml.edges()[*it].m_upward);
-		}
+    std::vector<int> cellIds;
+    for (std::vector<int>::const_iterator it = edgeIds.begin(); it != edgeIds.end(); ++it) {
+      merge<true>(cellIds, puml.edges()[*it].m_upward);
+    }
 
-		if (M)
-			merge<true>(lid, cellIds);
-		else
-			std::swap(lid, cellIds);
-	}
+    if (M)
+      merge<true>(lid, cellIds);
+    else
+      std::swap(lid, cellIds);
+  }
 
-private:
-	template<bool M>
-	static void merge(std::vector<int> &res, const std::vector<int> &v);
+  private:
+  template <bool M> static void merge(std::vector<int>& res, const std::vector<int>& v);
 };
 
-template<> inline
-void Upward::merge<false>(std::vector<int> &res, const std::vector<int> &v)
-{
-	res = v;
+template <> inline void Upward::merge<false>(std::vector<int>& res, const std::vector<int>& v) { res = v; }
+
+template <> inline void Upward::merge<true>(std::vector<int>& res, const std::vector<int>& v) {
+  std::vector<int> tmp;
+  std::set_union(v.begin(), v.end(), res.begin(), res.end(), std::back_inserter(tmp));
+  std::swap(tmp, res);
 }
 
-template<> inline
-void Upward::merge<true>(std::vector<int> &res, const std::vector<int> &v)
-{
-	std::vector<int> tmp;
-	std::set_union(v.begin(), v.end(),
-		res.begin(), res.end(),
-		std::back_inserter(tmp));
-	std::swap(tmp, res);
-}
-
-}
+} // namespace PUML
 
 #endif // PUML_UPWARD_H

--- a/Utils.h
+++ b/Utils.h
@@ -18,49 +18,37 @@
 #include "PUML.h"
 #include "Topology.h"
 
-namespace PUML
-{
+namespace PUML {
 
-namespace internal
-{
+namespace internal {
 
-template<TopoType Topo, typename E>
-struct ElementVector
-{
-	static const std::vector<E>& elements(const PUML<Topo> &puml);
+template <TopoType Topo, typename E> struct ElementVector {
+  static const std::vector<E>& elements(const PUML<Topo>& puml);
 };
 
-template<TopoType Topo>
-struct ElementVector<Topo, typename PUML<Topo>::cell_t>
-{
-	static const std::vector<typename PUML<Topo>::cell_t>& elements(const PUML<Topo> &puml)
-	{ return puml.cells(); }
+template <TopoType Topo> struct ElementVector<Topo, typename PUML<Topo>::cell_t> {
+  static const std::vector<typename PUML<Topo>::cell_t>& elements(const PUML<Topo>& puml) { return puml.cells(); }
 };
 
-template<TopoType Topo>
-struct ElementVector<Topo, typename PUML<Topo>::vertex_t>
-{
-	static const std::vector<typename PUML<Topo>::vertex_t>& elements(const PUML<Topo> &puml)
-	{ return puml.vertices(); }
+template <TopoType Topo> struct ElementVector<Topo, typename PUML<Topo>::vertex_t> {
+  static const std::vector<typename PUML<Topo>::vertex_t>& elements(const PUML<Topo>& puml) { return puml.vertices(); }
 };
 
-class Utils
-{
-public:
-	/**
-	 * Get the global ids for a set of local ids
-	 */
-	template<TopoType Topo, typename E, unsigned int N>
-	static void l2g(const PUML<Topo> &puml, const unsigned int lid[N], unsigned long gid[N])
-	{
-		const std::vector<E>& elements = ElementVector<Topo, E>::elements(puml);
-		for (unsigned int i = 0; i < N; i++)
-			gid[i] = elements[lid[i]].m_gid;
-	}
+class Utils {
+  public:
+  /**
+   * Get the global ids for a set of local ids
+   */
+  template <TopoType Topo, typename E, unsigned int N>
+  static void l2g(const PUML<Topo>& puml, const unsigned int lid[N], unsigned long gid[N]) {
+    const std::vector<E>& elements = ElementVector<Topo, E>::elements(puml);
+    for (unsigned int i = 0; i < N; i++)
+      gid[i] = elements[lid[i]].m_gid;
+  }
 };
 
-}
+} // namespace internal
 
-}
+} // namespace PUML
 
 #endif // PUML_UTILS_H

--- a/VertexElementMap.h
+++ b/VertexElementMap.h
@@ -17,104 +17,84 @@
 #include <cstring>
 #include <unordered_map>
 
-namespace PUML
-{
+namespace PUML {
 
-namespace internal
-{
+namespace internal {
 
 /**
  * Mapps from a list of local vertex ids to the local id of the element
  */
-template<unsigned int N>
-class VertexElementMap
-{
-private:
-	/**
-	 * Description of a element by the local vertex ids
-	 */
-	struct Element
-	{
-		/** The vertices that define this element */
-		unsigned int vertices[N];
+template <unsigned int N> class VertexElementMap {
+  private:
+  /**
+   * Description of a element by the local vertex ids
+   */
+  struct Element {
+    /** The vertices that define this element */
+    unsigned int vertices[N];
 
-		Element(const unsigned int vertices[N])
-		{
-			memcpy(this->vertices, vertices, N*sizeof(unsigned int));
-			std::sort(this->vertices, this->vertices+N);
-		}
+    Element(const unsigned int vertices[N]) {
+      memcpy(this->vertices, vertices, N * sizeof(unsigned int));
+      std::sort(this->vertices, this->vertices + N);
+    }
 
-		bool operator==(const Element &other) const
-		{
-			return memcmp(vertices, other.vertices, N*sizeof(unsigned int)) == 0;
-		}
-	};
+    bool operator==(const Element& other) const {
+      return memcmp(vertices, other.vertices, N * sizeof(unsigned int)) == 0;
+    }
+  };
 
-	struct ElementHash
-	{
-		std::size_t operator()(const Element &element) const
-		{
-			std::size_t h = std::hash<unsigned int>{}(element.vertices[0]);
-			for (unsigned int i = 1; i < N; i++)
-				hash_combine(h, element.vertices[i]);
+  struct ElementHash {
+    std::size_t operator()(const Element& element) const {
+      std::size_t h = std::hash<unsigned int>{}(element.vertices[0]);
+      for (unsigned int i = 1; i < N; i++)
+        hash_combine(h, element.vertices[i]);
 
-			return h;
-		}
-	};
+      return h;
+    }
+  };
 
-	std::unordered_map<Element, unsigned int, ElementHash> m_elements;
+  std::unordered_map<Element, unsigned int, ElementHash> m_elements;
 
-public:
-	VertexElementMap()
-	{ }
+  public:
+  VertexElementMap() {}
 
-	unsigned int add(const unsigned int vertices[N])
-	{
-		const Element e(vertices);
+  unsigned int add(const unsigned int vertices[N]) {
+    const Element e(vertices);
 
-		typename std::unordered_map<Element, unsigned int, ElementHash>::const_iterator it = m_elements.find(e);
-		if (it == m_elements.end()) {
-			unsigned int id = m_elements.size();
-			it = m_elements.emplace(e, id).first;
-		}
+    typename std::unordered_map<Element, unsigned int, ElementHash>::const_iterator it = m_elements.find(e);
+    if (it == m_elements.end()) {
+      unsigned int id = m_elements.size();
+      it = m_elements.emplace(e, id).first;
+    }
 
-		return it->second;
-	}
+    return it->second;
+  }
 
-	size_t size() const
-	{
-		return m_elements.size();
-	}
+  size_t size() const { return m_elements.size(); }
 
-	int find(unsigned int vertices[N]) const
-	{
-		typename std::unordered_map<Element, unsigned int, ElementHash>::const_iterator it = m_elements.find(vertices);
+  int find(unsigned int vertices[N]) const {
+    typename std::unordered_map<Element, unsigned int, ElementHash>::const_iterator it = m_elements.find(vertices);
 
-		if (it == m_elements.end())
-			return -1;
+    if (it == m_elements.end())
+      return -1;
 
-		return it->second;
-	}
+    return it->second;
+  }
 
-	void clear()
-	{
-		m_elements.clear();
-	}
+  void clear() { m_elements.clear(); }
 
-private:
-	/**
-	 * Taken from: https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
-	 */
-	template<typename T>
-	static void hash_combine(std::size_t& seed, const T& v)
-	{
-		std::hash<T> hasher;
-		seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-	}
+  private:
+  /**
+   * Taken from: https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
+   */
+  template <typename T> static void hash_combine(std::size_t& seed, const T& v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
 };
 
-}
+} // namespace internal
 
-}
+} // namespace PUML
 
 #endif // PUML_VERTEXELEMENTMAP_H


### PR DESCRIPTION
To achieve a better partitioning we need to allow partitioning with edge weights. PUML2 has to be adapted to use Metis with edge weights.

New functions are implemented to generate the dual graph of the mesh. (generateGraphFromMesh()) and to get the graph representation of METIS (getGraph())
 The old partition(...) method is changed to to accept edgeweights with the new arguments (const int* edgeWeights, size_t edgeCount). The new implementation first creates the dual graph of the mesh and then partitions it with the ParMETIS_V3_PartKway. Instead of directly partitioning the mesh.
 
 Applying no edge weights and partitioning the dual graph provides the same result with paritioning the mesh directly.