### PR TITLE
Fix HDF5 errors with large number of ranks

### DIFF
--- a/PUML.h
+++ b/PUML.h
@@ -78,7 +78,7 @@ class Distributor {
       offset = missingEntities * (entitiesPerRank + 1) + (rank - missingEntities) * entitiesPerRank;
       size = std::min(entitiesPerRank, numEntities - offset);
     }
-    assert(offset + size < numEntities);
+    assert(offset + size <= numEntities);
     return {offset, size};
   }
 

--- a/PUML.h
+++ b/PUML.h
@@ -86,7 +86,7 @@ class Distributor {
    * Gives the rank, which has read the entity with the given globalId.
    */
   unsigned long rankOfEntity(unsigned long globalId) {
-    assert(id < numEntities);
+    assert(globalId < numEntities);
     unsigned long rank = 0;
     if (globalId < missingEntities * (entitiesPerRank + 1)) {
       rank = globalId / (entitiesPerRank + 1);


### PR DESCRIPTION
When using a lot of ranks, we obtained some HDF5 errors, see e.g. https://github.com/SeisSol/SeisSol/issues/718
This pull request fixes that issue, by introducing a new vertex distribution:
If we have `V` vertices and `R` ranks, the first `V%R` ranks will read `V/R + 1` elements and the remaining ranks will read `V/R` ranks. 
Todo: Consider the same distribution for the element array.