### PR TITLE
Allow More Types in Data Arrays

### DIFF
--- a/FaceIterator.h
+++ b/FaceIterator.h
@@ -26,30 +26,12 @@
 #include <type_traits>
 #include <utility>
 #include "Upward.h"
+#include "TypeInference.h"
 
 #include "utils/logger.h"
 
 namespace PUML
 {
-
-#ifdef USE_MPI
-template<typename T> class MPITypeInfer;
-template<> class MPITypeInfer<char> { public: static MPI_Datatype type() { return MPI_CHAR; } };
-template<> class MPITypeInfer<signed char> { public: static MPI_Datatype type() { return MPI_SIGNED_CHAR; } };
-template<> class MPITypeInfer<unsigned char> { public: static MPI_Datatype type() { return MPI_UNSIGNED_CHAR; } };
-template<> class MPITypeInfer<short> { public: static MPI_Datatype type() { return MPI_SHORT; } };
-template<> class MPITypeInfer<unsigned short> { public: static MPI_Datatype type() { return MPI_UNSIGNED_SHORT; } };
-template<> class MPITypeInfer<int> { public: static MPI_Datatype type() { return MPI_INT; } };
-template<> class MPITypeInfer<unsigned> { public: static MPI_Datatype type() { return MPI_UNSIGNED; } };
-template<> class MPITypeInfer<long> { public: static MPI_Datatype type() { return MPI_LONG; } };
-template<> class MPITypeInfer<unsigned long> { public: static MPI_Datatype type() { return MPI_UNSIGNED_LONG; } };
-template<> class MPITypeInfer<long long> { public: static MPI_Datatype type() { return MPI_LONG_LONG; } };
-template<> class MPITypeInfer<unsigned long long> { public: static MPI_Datatype type() { return MPI_UNSIGNED_LONG_LONG; } };
-template<> class MPITypeInfer<float> { public: static MPI_Datatype type() { return MPI_FLOAT; } };
-template<> class MPITypeInfer<double> { public: static MPI_Datatype type() { return MPI_DOUBLE; } };
-template<> class MPITypeInfer<long double> { public: static MPI_Datatype type() { return MPI_LONG_DOUBLE; } };
-template<> class MPITypeInfer<wchar_t> { public: static MPI_Datatype type() { return MPI_WCHAR; } };
-#endif
 
 template<TopoType Topo>
 class FaceIterator

--- a/PUML.h
+++ b/PUML.h
@@ -369,7 +369,7 @@ public:
 	}
 
     template<typename T>
-	void addData(const T* rawData, unsigned long dataSize, DataType type
+	void addDataArray(const T* rawData, DataType type
 #ifdef USE_MPI
 		, MPI_Datatype mpiType = MPITypeInfer<T>::type()
 #endif
@@ -387,13 +387,8 @@ public:
 		auto cellDistributor = Distributor(m_originalTotalSize[type], procs);
 		auto[offset, localSize] = cellDistributor.offsetAndSize(rank);
 
-		unsigned long totalSize = m_originalTotalSize[type];
-		if (dataSize != totalSize) {
-			logError() << "Data has the wrong size, expected" << totalSize << ", but got" << dataSize;
-		}
-
 		void* data = std::malloc(sizeof(T) * localSize);
-        std::memcpy(data, rawData + offset, sizeof(T) * localSize);
+        std::memcpy(data, rawData, sizeof(T) * localSize);
 		switch (type) {
 		case CELL:
 			m_cellData.push_back(data);

--- a/PUML.h
+++ b/PUML.h
@@ -602,8 +602,8 @@ public:
 		// Exchange cell data
 		for (std::size_t j = 0; j < m_cellData.size(); ++j) {
 			void* newData = std::malloc(m_originalSize[0] * m_cellDataSize[j]);
-			MPI_Alltoallv(m_cellData[j], sendCount, sDispls, MPI_INT,
-				newData, recvCount, rDispls, MPI_INT,
+			MPI_Alltoallv(m_cellData[j], sendCount, sDispls, m_cellDataType[j],
+				newData, recvCount, rDispls, m_cellDataType[j],
 				m_comm);
 
 			std::free(m_cellData[j]);
@@ -734,8 +734,8 @@ public:
 		MPI_Type_free(&vertexType);
 
 		for (unsigned int i = 0; i < m_originalVertexData.size(); i++) {
-			MPI_Alltoallv(distribData[i], recvCount, rDispls, MPI_INT,
-				m_vertexData[i], sendCount, sDispls, MPI_INT,
+			MPI_Alltoallv(distribData[i], recvCount, rDispls, m_vertexDataType[i],
+				m_vertexData[i], sendCount, sDispls, m_vertexDataType[i],
 				m_comm);
 		}
 #endif // USE_MPI

--- a/PUML.h
+++ b/PUML.h
@@ -601,7 +601,7 @@ public:
 		for (std::size_t j = 0; j < m_cellData.size(); ++j) {
 			void* newData = std::malloc(m_originalSize[0] * m_cellDataSize[j]);
 			for (unsigned int i = 0; i < m_originalSize[0]; i++) {
-				std::memcpy(reinterpret_cast<std::byte*>(newData) + m_cellDataSize[j] * i, reinterpret_cast<std::byte*>(m_cellData[j]) + m_cellDataSize[j] * indices[i], m_cellDataSize[j]);
+				std::memcpy(reinterpret_cast<char*>(newData) + m_cellDataSize[j] * i, reinterpret_cast<char*>(m_cellData[j]) + m_cellDataSize[j] * indices[i], m_cellDataSize[j]);
 			}
 
 			std::free(m_cellData[j]);
@@ -757,7 +757,7 @@ public:
 
 				// Handle other vertex data
 				for (unsigned int l = 0; l < m_originalVertexData.size(); l++) {
-					std::memcpy(reinterpret_cast<std::byte*>(distribData[l]) + m_vertexDataSize[l] * k, reinterpret_cast<std::byte*>(m_originalVertexData[l]) + m_vertexDataSize[l] * distribVertexIds[k], m_vertexDataSize[l]);
+					std::memcpy(reinterpret_cast<char*>(distribData[l]) + m_vertexDataSize[l] * k, reinterpret_cast<char*>(m_originalVertexData[l]) + m_vertexDataSize[l] * distribVertexIds[k], m_vertexDataSize[l]);
 				}
 
 				// Save all ranks for each vertex

--- a/TypeInference.h
+++ b/TypeInference.h
@@ -1,0 +1,62 @@
+/**
+ * @file
+ *  This file is part of PUML
+ *
+ *  For conditions of distribution and use, please see the copyright
+ *  notice in the file 'COPYING' at the root directory of this package
+ *  and the copyright notice at https://github.com/TUM-I5/PUMGen
+ *
+ * @copyright 2019-2023 Technische Universitaet Muenchen
+ * @author David Schneller <david.schneller@tum.de>
+ */
+
+#ifndef PUML_TYPE_INFERENCE_H
+#define PUML_TYPE_INFERENCE_H
+
+#ifdef USE_MPI
+#include <mpi.h>
+#endif // USE_MPI
+
+#include <hdf5.h>
+
+namespace PUML
+{
+
+#ifdef USE_MPI
+template<typename T> class MPITypeInfer { public: static MPI_Datatype type() { return MPI_BYTE; } };
+template<> class MPITypeInfer<char> { public: static MPI_Datatype type() { return MPI_CHAR; } };
+template<> class MPITypeInfer<signed char> { public: static MPI_Datatype type() { return MPI_SIGNED_CHAR; } };
+template<> class MPITypeInfer<unsigned char> { public: static MPI_Datatype type() { return MPI_UNSIGNED_CHAR; } };
+template<> class MPITypeInfer<short> { public: static MPI_Datatype type() { return MPI_SHORT; } };
+template<> class MPITypeInfer<unsigned short> { public: static MPI_Datatype type() { return MPI_UNSIGNED_SHORT; } };
+template<> class MPITypeInfer<int> { public: static MPI_Datatype type() { return MPI_INT; } };
+template<> class MPITypeInfer<unsigned> { public: static MPI_Datatype type() { return MPI_UNSIGNED; } };
+template<> class MPITypeInfer<long> { public: static MPI_Datatype type() { return MPI_LONG; } };
+template<> class MPITypeInfer<unsigned long> { public: static MPI_Datatype type() { return MPI_UNSIGNED_LONG; } };
+template<> class MPITypeInfer<long long> { public: static MPI_Datatype type() { return MPI_LONG_LONG; } };
+template<> class MPITypeInfer<unsigned long long> { public: static MPI_Datatype type() { return MPI_UNSIGNED_LONG_LONG; } };
+template<> class MPITypeInfer<float> { public: static MPI_Datatype type() { return MPI_FLOAT; } };
+template<> class MPITypeInfer<double> { public: static MPI_Datatype type() { return MPI_DOUBLE; } };
+template<> class MPITypeInfer<long double> { public: static MPI_Datatype type() { return MPI_LONG_DOUBLE; } };
+template<> class MPITypeInfer<wchar_t> { public: static MPI_Datatype type() { return MPI_WCHAR; } };
+#endif
+
+template<typename T> class HDF5TypeInfer { public: static hid_t type() { return -1; } };
+template<> class HDF5TypeInfer<char> { public: static hid_t type() { return H5T_NATIVE_CHAR; } };
+template<> class HDF5TypeInfer<signed char> { public: static hid_t type() { return H5T_NATIVE_SCHAR; } };
+template<> class HDF5TypeInfer<unsigned char> { public: static hid_t type() { return H5T_NATIVE_UCHAR; } };
+template<> class HDF5TypeInfer<short> { public: static hid_t type() { return H5T_NATIVE_SHORT; } };
+template<> class HDF5TypeInfer<unsigned short> { public: static hid_t type() { return H5T_NATIVE_USHORT; } };
+template<> class HDF5TypeInfer<int> { public: static hid_t type() { return H5T_NATIVE_INT; } };
+template<> class HDF5TypeInfer<unsigned> { public: static hid_t type() { return H5T_NATIVE_UINT; } };
+template<> class HDF5TypeInfer<long> { public: static hid_t type() { return H5T_NATIVE_LONG; } };
+template<> class HDF5TypeInfer<unsigned long> { public: static hid_t type() { return H5T_NATIVE_ULONG; } };
+template<> class HDF5TypeInfer<long long> { public: static hid_t type() { return H5T_NATIVE_LLONG; } };
+template<> class HDF5TypeInfer<unsigned long long> { public: static hid_t type() { return H5T_NATIVE_ULLONG; } };
+template<> class HDF5TypeInfer<float> { public: static hid_t type() { return H5T_NATIVE_FLOAT; } };
+template<> class HDF5TypeInfer<double> { public: static hid_t type() { return H5T_NATIVE_DOUBLE; } };
+template<> class HDF5TypeInfer<long double> { public: static hid_t type() { return H5T_NATIVE_LDOUBLE; } };
+
+} // namespace PUML
+
+#endif

--- a/test/simple-test/CMakeLists.txt
+++ b/test/simple-test/CMakeLists.txt
@@ -14,13 +14,11 @@ add_executable(tests ./puml.cpp)
 target_include_directories(tests PRIVATE
         ../..
         ../../submodules
-        ${PARMETIS_INCLUDE_DIRS}
         ${HDF5_INCLUDE_DIRS}
         ${MPI_CXX_INCLUDE_DIRS}
         )
 
 target_link_libraries(tests
-        ${PARMETIS_LIBRARIES}
         ${HDF5_C_HL_LIBRARIES}
         ${HDF5_C_LIBRARIES}
         ${MPI_CXX_LIBRARIES})

--- a/test/simple-test/CMakeLists.txt
+++ b/test/simple-test/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.9)
+project(tests)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/../cmake" ${CMAKE_MODULE_PATH})
+
+find_package(MPI REQUIRED)
+find_package(HDF5 REQUIRED COMPONENTS C HL)
+
+add_executable(tests ./puml.cpp)
+target_include_directories(tests PRIVATE
+        ../..
+        ../../submodules
+        ${MPI_CXX_INCLUDE_DIRS}
+        ${HDF5_INCLUDE_DIRS}
+        ${PARMETIS_INCLUDE_DIRS})
+
+target_link_libraries(tests
+        ${MPI_CXX_LIBRARIES}
+        ${HDF5_C_HL_LIBRARIES}
+        ${HDF5_C_LIBRARIES}
+        ${PARMETIS_LIBRARIES})
+
+target_compile_definitions(tests PRIVATE USE_MPI REAL_SIZE=8)
+
+enable_testing()
+add_test(NAME tests COMMAND tests)

--- a/test/simple-test/CMakeLists.txt
+++ b/test/simple-test/CMakeLists.txt
@@ -14,15 +14,16 @@ add_executable(tests ./puml.cpp)
 target_include_directories(tests PRIVATE
         ../..
         ../../submodules
-        ${MPI_CXX_INCLUDE_DIRS}
+        ${PARMETIS_INCLUDE_DIRS}
         ${HDF5_INCLUDE_DIRS}
-        ${PARMETIS_INCLUDE_DIRS})
+        ${MPI_CXX_INCLUDE_DIRS}
+        )
 
 target_link_libraries(tests
-        ${MPI_CXX_LIBRARIES}
+        ${PARMETIS_LIBRARIES}
         ${HDF5_C_HL_LIBRARIES}
         ${HDF5_C_LIBRARIES}
-        ${PARMETIS_LIBRARIES})
+        ${MPI_CXX_LIBRARIES})
 
 target_compile_definitions(tests PRIVATE USE_MPI REAL_SIZE=8)
 

--- a/test/simple-test/puml.cpp
+++ b/test/simple-test/puml.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file
+ *  This file is part of PUML
+ *
+ *  For conditions of distribution and use, please see the copyright
+ *  notice in the file 'COPYING' at the root directory of this package
+ *  and the copyright notice at https://github.com/TUM-I5/PUMGen
+ *
+ * @copyright 2017 Technische Universitaet Muenchen
+ * @author Sebastian Rettenberger <sebastian.rettenberger@tum.de>
+ */
+
+#include <mpi.h>
+
+#include "utils/args.h"
+#include "utils/logger.h"
+
+#include "PUML.h"
+#include "Downward.h"
+#include "Neighbor.h"
+#include "Partition.h"
+#include "PartitionGraph.h"
+
+#include <sstream>
+#include <vector>
+#include <type_traits>
+
+template<typename T>
+void printElement(std::stringstream& stream, const T& data) {
+	if constexpr (std::is_array_v<T>) {
+		for (std::size_t i = 0; i < std::extent_v<T, 0>; ++i) {
+			if (i > 0) {
+				stream << ",";
+			}
+			printElement(stream, data[i]);
+		}
+	}
+	else {
+		stream << data;
+	}
+}
+
+/*template<>
+static void printElement<PUML::TETPUML::cell_t>(std::stringstream& stream, const PUML::TETPUML::cell_t& data) {
+	PUML::Downward::vertices();
+}*/
+
+template<>
+void printElement<PUML::TETPUML::vertex_t>(std::stringstream& stream, const PUML::TETPUML::vertex_t& data) {
+	const auto& cref = data.coordinate();
+	double coords[3] = {cref[0], cref[1], cref[2]};
+	printElement(stream, coords);
+}
+
+template<typename T>
+static void printArray(const T* data, std::size_t size) {
+	int rank;
+	int rsize;
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &rsize);
+
+	unsigned long long countSoFar = 0;
+
+	if (rank > 0) {
+		MPI_Recv(&countSoFar, 1, MPI_UNSIGNED_LONG_LONG, rank - 1, 15, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+	}
+
+	logInfo(0) << "Rank" << rank;
+
+	std::stringstream stream;
+	for (std::size_t i = 0; i < size; ++i) {
+		stream << countSoFar << ": ";
+		printElement(stream, data[i]);
+		logInfo(0) << stream.str().c_str();
+		stream.str("");
+		++countSoFar;
+	}
+
+	if (rank < rsize - 1) {
+		MPI_Send(&countSoFar, 1, MPI_UNSIGNED_LONG_LONG, rank + 1, 15, MPI_COMM_WORLD);
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+}
+
+template<typename T>
+static void printArray(const std::vector<T>& data) {
+	printArray(data.data(), data.size());
+}
+
+int main(int argc, char* argv[])
+{
+	MPI_Init(&argc, &argv);
+
+	int rank;
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+	utils::Args args;
+	args.addAdditionalOption("in", "the PUML mesh file");
+
+	switch (args.parse(argc, argv)) {
+	case utils::Args::Error:
+		MPI_Abort(MPI_COMM_WORLD, -1);
+		break;
+	case utils::Args::Help:
+		MPI_Finalize();
+		return 1;
+	}
+
+	PUML::TETPUML puml;
+
+	std::string infile = args.getAdditionalArgument<const char*>("in");
+
+	// Read the mesh
+	logInfo(rank) << "Reading mesh";
+	puml.open((infile + ":/connect").c_str(), (infile + ":/geometry").c_str());
+
+	logInfo(rank) << "Reading other data (i.e. groups, boundaries)";
+	puml.addData((infile  + ":/group").c_str(), PUML::CELL);
+	puml.addData((infile  + ":/boundary").c_str(), PUML::CELL);
+
+	std::vector<unsigned long long> test(puml.numOriginalCells(), 0x5555555555555555ULL);
+	puml.addData(test.data(), puml.numOriginalCells(), PUML::CELL);
+
+	// Generate the mesh information
+	logInfo(rank) << "Generating mesh information";
+	puml.generateMesh();
+
+	// Write test
+	logInfo(rank) << "Printing test information";
+	const std::vector<PUML::TETPUML::cell_t> &cells = puml.cells();
+
+	const std::vector<PUML::TETPUML::vertex_t> &vertices = puml.vertices();
+	printArray(vertices);
+
+	const int* groups = reinterpret_cast<const int*>(puml.cellData(0));
+	printArray(groups, cells.size());
+	const unsigned long long* testt = reinterpret_cast<const unsigned long long*>(puml.cellData(2));
+	printArray(testt, cells.size());
+
+	logInfo(rank) << "Done";
+
+	MPI_Finalize();
+
+	return 0;
+}

--- a/test/simple-test/puml.cpp
+++ b/test/simple-test/puml.cpp
@@ -116,11 +116,11 @@ int main(int argc, char* argv[])
 	puml.open((infile + ":/connect").c_str(), (infile + ":/geometry").c_str());
 
 	logInfo(rank) << "Reading other data (i.e. groups, boundaries)";
-	puml.addData((infile  + ":/group").c_str(), PUML::CELL);
-	puml.addData((infile  + ":/boundary").c_str(), PUML::CELL);
+	puml.addData<int>((infile  + ":/group").c_str(), PUML::CELL, {});
+	puml.addData<int>((infile  + ":/boundary").c_str(), PUML::CELL, {});
 
 	std::vector<unsigned long long> test(puml.numOriginalCells(), 0x5555555555555555ULL);
-	puml.addDataArray(test.data(), PUML::CELL);
+	puml.addDataArray<unsigned long long>(test.data(), PUML::CELL, {});
 
 	// Generate the mesh information
 	logInfo(rank) << "Generating mesh information";

--- a/test/simple-test/puml.cpp
+++ b/test/simple-test/puml.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
 	puml.addData((infile  + ":/boundary").c_str(), PUML::CELL);
 
 	std::vector<unsigned long long> test(puml.numOriginalCells(), 0x5555555555555555ULL);
-	puml.addData(test.data(), puml.numOriginalCells(), PUML::CELL);
+	puml.addDataArray(test.data(), PUML::CELL);
 
 	// Generate the mesh information
 	logInfo(rank) << "Generating mesh information";

--- a/test/simple-test/puml.cpp
+++ b/test/simple-test/puml.cpp
@@ -6,11 +6,15 @@
  *  notice in the file 'COPYING' at the root directory of this package
  *  and the copyright notice at https://github.com/TUM-I5/PUMGen
  *
- * @copyright 2017 Technische Universitaet Muenchen
- * @author Sebastian Rettenberger <sebastian.rettenberger@tum.de>
+ * @copyright 2024 Technische Universitaet Muenchen
+ * @author David Schneller <david.schneller@tum.de>
  */
 
 #include <mpi.h>
+
+#include <sstream>
+#include <vector>
+#include <type_traits>
 
 #include "utils/args.h"
 #include "utils/logger.h"
@@ -20,10 +24,6 @@
 #include "Neighbor.h"
 #include "Partition.h"
 #include "PartitionGraph.h"
-
-#include <sstream>
-#include <vector>
-#include <type_traits>
 
 template<typename T>
 void printElement(std::stringstream& stream, const T& data) {


### PR DESCRIPTION
This PR does two changes:

* we allow more primitive data types to be used in additional data fields (unfortunately, by using more plain C mechanisms)
* additional data arrays (which are not from HDF5 files) now only require the values for the locally-present cells or vertices (and not all of them) anymore.

Effectively needed for huge meshes in SeisSol (i.e. more than 2.14 bln cells)—otherwise the mesh correctness test will strike. (note that this PR does not adjust PUML where still needed)